### PR TITLE
[WIP] Convert lossless images on download

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "app/src/main/jni/libwebp"]
+	path = app/src/main/jni/libwebp
+	url = https://chromium.googlesource.com/webm/libwebp

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 custom.gradle
 google-services.json
+.externalNativeBuild

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,12 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86"
         }
+
+        externalNativeBuild {
+            ndkBuild {
+                targets 'webp_encoder'
+            }
+        }
     }
 
     buildTypes {
@@ -97,10 +103,14 @@ android {
         checkReleaseBuilds false
     }
 
+    externalNativeBuild {
+        ndkBuild {
+            path "src/main/jni/Android.mk"
+        }
+    }
 }
 
 dependencies {
-
     // Modified dependencies
     implementation 'com.github.inorichi:subsampling-scale-image-view:81b9d68'
     implementation 'com.github.inorichi:junrar-android:634c1f5'

--- a/app/src/main/java/eu/kanade/tachiyomi/data/encoder/Encoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/encoder/Encoder.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.data.encoder
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import java.util.concurrent.TimeUnit
+import timber.log.Timber
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class Encoder(
+        private val preferences: PreferencesHelper = Injekt.get()
+) {
+
+    companion object {
+        // Conversion options
+        const val DISABLED = -1
+        const val LOSSLESS_WEBP = 0
+        const val LOSSY_WEBP = 1
+    }
+
+    private fun enumStr(value: Int): String {
+        return when (value) {
+            DISABLED -> "DISABLED"
+            LOSSLESS_WEBP -> "LOSSLESS_WEBP"
+            LOSSY_WEBP -> "LOSSY_WEBP"
+            else -> "Unknown value $value"
+        }
+    }
+
+    fun logTime(label: String, time: Long) {
+        var min = TimeUnit.NANOSECONDS.toMinutes(time)
+        var sec = TimeUnit.NANOSECONDS.toSeconds(time) - TimeUnit.MINUTES.toSeconds(TimeUnit.NANOSECONDS.toMinutes(time))
+        var mill = TimeUnit.NANOSECONDS.toMillis(time) - TimeUnit.SECONDS.toMillis(TimeUnit.NANOSECONDS.toSeconds(time))
+        Timber.i("WEBP_ENC: $label took $min:$sec:$mill ($time ns)")
+    }
+
+    private fun encode(bitmap: Bitmap, outDir: UniFile, filename: String): Boolean {
+        var lossless = false;
+        var extension = "";
+
+        val encodeSetting = preferences.convertLosslessDownloads()
+        when (encodeSetting) {
+            DISABLED -> return false
+            LOSSLESS_WEBP -> {
+                lossless = true
+                extension = "webp"
+            }
+            LOSSY_WEBP -> {
+                lossless = false
+                extension = "webp"
+            }
+            else -> {
+                Timber.e("Unknown encode setting");
+                return false;
+            }
+        }
+
+        val outFile = outDir.createFile("$filename.out")
+
+        // encode
+        val encodeStart = System.nanoTime()
+        var stream = outFile.openOutputStream()
+        val success = when (encodeSetting) {
+            LOSSLESS_WEBP, LOSSY_WEBP -> WebpEncoder.encode(bitmap, lossless, stream)
+            else -> false
+        }
+        stream.close()
+        val encodeEnd = System.nanoTime()
+        logTime("encode", encodeEnd - encodeStart)
+
+        if (success) {
+            outFile.renameTo("$filename.$extension")
+        } else {
+            Timber.e("Encoding failed for ${outDir.filePath}/$filename")
+            outFile.delete()
+        }
+
+        return success
+    }
+
+    fun encodeChapter(mangaDir: UniFile, chapterDir: UniFile, chapterDirname: String) {
+        // Todo: Do this async to the download on the computation scheduler
+
+        if (preferences.convertLosslessDownloads() == DISABLED) {
+            return
+        }
+
+        // Only pngs are supported for now
+        val images = chapterDir.listFiles().orEmpty().filter { it.name!!.endsWith("png")}
+        images.forEach {
+            val origExtension = it.name!!.substringAfterLast('.')
+            val filename = it.name!!.substringBeforeLast('.')
+
+            // TODO: do not use bitmap at all, use embedded libwebp png decoder
+            // decodeFile
+            val decodeStart = System.nanoTime()
+            var bitmap = BitmapFactory.decodeFile(it.filePath)
+            val decodeEnd = System.nanoTime()
+            logTime("decodeFile", decodeEnd - decodeStart)
+
+            if (bitmap != null && encode(bitmap, chapterDir, filename)) {
+                it.delete()
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/encoder/WebpEncoder.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/encoder/WebpEncoder.java
@@ -1,0 +1,64 @@
+package eu.kanade.tachiyomi.data.encoder;
+
+import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import android.util.Log;
+
+import timber.log.Timber;
+
+public class WebpEncoder {
+    private static boolean initialized = false;
+
+    static {
+        System.loadLibrary("webp_encoder");
+        initialized = nativeInitialize();
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    private static boolean validateBitmap(@NonNull Bitmap bitmap) {
+        // Currently only ARGB_8888 bitmaps are supported, they are the most common format
+        return Bitmap.Config.ARGB_8888.equals(bitmap.getConfig());
+    }
+
+    public static boolean encode(@NonNull Bitmap bitmap, boolean lossless, @NonNull OutputStream out) {
+        if (!isInitialized()) {
+            Timber.e("WebpEncoder not initialized");
+            return false;
+        }
+
+        if (!validateBitmap(bitmap)) {
+            Timber.e("Bitmap config %s is not supported", bitmap.getConfig());
+            return false;
+        }
+
+        int bpp = 4; // ARGB_8888 is 4 bytes per pixel
+
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+        int stride = bpp * width;
+        int size = stride * height;
+        boolean opaque = !bitmap.hasAlpha();
+
+        if (stride != bitmap.getRowBytes()) {
+            Timber.e("Stride of %d does not match rowBytes %d", stride, bitmap.getRowBytes());
+            return false;
+        }
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+        bitmap.copyPixelsToBuffer(byteBuffer);
+
+        return nativeEncode(byteBuffer.array(), width, height, stride, opaque, lossless, out);
+    }
+
+    private native static boolean nativeInitialize();
+
+    private native static boolean nativeEncode(@NonNull byte[] rgba, int width, int height,
+                                               int stride, boolean opaque, boolean lossless,
+                                               @NonNull OutputStream out);
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -71,6 +71,8 @@ object PreferenceKeys {
 
     const val downloadOnlyOverWifi = "pref_download_only_over_wifi_key"
 
+    const val convertLosslessDownloads = "pref_convert_lossless_downloads"
+
     const val numberOfBackups = "backup_slots"
 
     const val backupInterval = "backup_interval"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -127,6 +127,8 @@ class PreferencesHelper(val context: Context) {
 
     fun downloadOnlyOverWifi() = prefs.getBoolean(Keys.downloadOnlyOverWifi, true)
 
+    fun convertLosslessDownloads() = prefs.getInt(Keys.convertLosslessDownloads, -1)
+
     fun numberOfBackups() = rxPrefs.getInteger(Keys.numberOfBackups, 1)
 
     fun backupInterval() = rxPrefs.getInteger(Keys.backupInterval, 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -62,6 +62,18 @@ class SettingsDownloadController : SettingsController() {
             defaultValue = true
         }
         preferenceCategory {
+            titleRes = R.string.pref_convert_lossless_downloads
+
+            intListPreference {
+                key = Keys.convertLosslessDownloads
+                titleRes = R.string.pref_convert_lossless_downloads
+                entriesRes = arrayOf(R.string.disabled, R.string.lossless_webp, R.string.lossy_webp)
+                entryValues = arrayOf("-1", "0", "1")
+                defaultValue = "-1"
+                summary = "%s"
+            }
+        }
+        preferenceCategory {
             titleRes = R.string.pref_remove_after_read
 
             switchPreference {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -67,8 +67,8 @@ class SettingsDownloadController : SettingsController() {
             intListPreference {
                 key = Keys.convertLosslessDownloads
                 titleRes = R.string.pref_convert_lossless_downloads
-                entriesRes = arrayOf(R.string.disabled, R.string.lossless_webp, R.string.lossy_webp)
-                entryValues = arrayOf("-1", "0", "1")
+                entriesRes = arrayOf(R.string.disabled, R.string.lossless_webp, R.string.lossy_webp, R.string.jpg)
+                entryValues = arrayOf("-1", "0", "1", "2")
                 defaultValue = "-1"
                 summary = "%s"
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
@@ -42,6 +42,8 @@ object DiskUtil {
                     return "image/jpeg"
                 } else if (bytes[0] == 'W'.toByte() && bytes[1] == 'E'.toByte() && bytes[2] == 'B'.toByte() && bytes[3] == 'P'.toByte()) {
                     return "image/webp"
+                } else if (bytes[0] == 'R'.toByte() && bytes[1] == 'I'.toByte() && bytes[2] == 'F'.toByte() && bytes[3] == 'F'.toByte()) {
+                    return "image/webp"
                 }
             }
         } catch(e: Exception) {

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -1,0 +1,65 @@
+LOCAL_PATH := $(call my-dir)
+
+THIS_PATH := $(LOCAL_PATH)
+LIBWEBP_PATH := $(THIS_PATH)/libwebp
+
+CFLAGS := -Wall \
+          -Werror \
+          -O2 \
+          -DANDROID \
+          -DWEBP_SWAP_16BIT_CSP \
+
+
+################################################################################
+# libwebp-opt - compiles a static archive of libwebp with optimizations
+
+include $(LIBWEBP_PATH)/Android.mk
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(LIBWEBP_PATH)
+
+LOCAL_MODULE := webp-opt
+
+LOCAL_SRC_FILES := \
+    $(dec_srcs) \
+    $(dsp_dec_srcs) \
+    $(enc_srcs) \
+    $(dsp_enc_srcs) \
+    $(mux_srcs) \
+    $(utils_dec_srcs) \
+    $(utils_enc_srcs) \
+
+LOCAL_CFLAGS := $(CFLAGS)
+LOCAL_C_INCLUDES += $(LIBWEBP_PATH)/src
+
+# prefer arm over thumb mode for performance gains
+LOCAL_ARM_MODE := arm
+
+include $(BUILD_STATIC_LIBRARY)
+
+################################################################################
+# libwebp_encoder - compiles webp_encoder with libwebp static library
+
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(THIS_PATH)
+LOCAL_SRC_FILES := $(THIS_PATH)/webp_encoder.cpp
+LOCAL_C_INCLUDES := $(LIBWEBP_PATH)/src
+
+LOCAL_CFLAGS := $(CFLAGS)
+LOCAL_CPPFLAGS := -std=c++11
+
+# Debug release contains logging
+ifneq ($(APP_OPTIM),release)
+    LOCAL_LDLIBS := -llog
+    LOCAL_CFLAGS += "-DDEBUG"
+endif
+
+# prefer arm over thumb mode for performance gains
+LOCAL_ARM_MODE := arm
+
+LOCAL_WHOLE_STATIC_LIBRARIES := webp-opt
+
+LOCAL_MODULE := webp_encoder
+
+include $(BUILD_SHARED_LIBRARY)

--- a/app/src/main/jni/webp_encoder.cpp
+++ b/app/src/main/jni/webp_encoder.cpp
@@ -1,0 +1,192 @@
+#include <jni.h>
+
+extern "C" {
+#include <webp/encode.h>
+}
+
+#define LOG_TAG "WEBP_ENC"
+
+#ifdef DEBUG
+    #include <android/log.h>
+    #define LOG(SEV, FMT, ...) __android_log_print(SEV, LOG_TAG, "(%s:%d) " FMT, __func__, __LINE__, ## __VA_ARGS__)
+#else
+    #define LOG(...)
+#endif
+
+#define LOGE(...) LOG(ANDROID_LOG_ERROR, __VA_ARGS__)
+#define LOGW(...) LOG(ANDROID_LOG_WARN, __VA_ARGS__)
+#define LOGD(...) LOG(ANDROID_LOG_DEBUG, __VA_ARGS__)
+#define LOGI(...) LOG(ANDROID_LOG_INFO, __VA_ARGS__)
+
+
+#define STORAGE_BUF_SIZE 4096
+
+#define LOSSLESS_LEVEL 2
+#define LOSSY_QUALITY 90
+
+static jmethodID gOutputStream_write = nullptr;
+
+struct encode_context {
+    JNIEnv* env;
+    jbyteArray tmp_buf;
+    jobject output_stream;
+};
+
+extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
+{
+    LOGI("onLoad");
+    JNIEnv* env;
+    if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return -1;
+    }
+
+    return JNI_VERSION_1_6;
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_eu_kanade_tachiyomi_data_encoder_WebpEncoder_nativeInitialize(JNIEnv *env, jclass type) {
+    static bool initialized = false;
+
+    // TODO: use a mutex since this is not threadsafe
+    if (initialized) {
+        return true;
+    }
+
+    LOGI("nativeInitialize");
+
+    jclass outputStream_class = env->FindClass("java/io/OutputStream");
+    if (outputStream_class == nullptr) {
+        LOGE("Could not find OutputStream class");
+        return false;
+    }
+
+    gOutputStream_write = env->GetMethodID(outputStream_class, "write", "([BII)V");
+    if (gOutputStream_write == nullptr) {
+        LOGE("Could not find write method of OutputStream");
+        return false;
+    }
+
+    initialized = true;
+    return true;
+}
+
+static int webp_write_callback(const uint8_t* data, size_t size, const WebPPicture* picture) {
+    struct encode_context* ctx = (struct encode_context*) picture->custom_ptr;
+
+    JNIEnv* env = ctx->env;
+    jbyteArray tmp_buf = ctx->tmp_buf;
+    jobject output_stream = ctx->output_stream;
+    jsize buf_cap = env->GetArrayLength(tmp_buf);
+
+    if (buf_cap <= 0) {
+        LOGE("Cannot use tmp_buf of size %d", buf_cap);
+        return false;
+    }
+
+    // Write the data in chunks to the output stream
+    while (size > 0) {
+        size_t chunk_size = size;
+        if (chunk_size > (size_t)buf_cap) {
+            chunk_size = (size_t)buf_cap;
+        }
+
+        // Update tmp_buf with chunk data
+        env->SetByteArrayRegion(tmp_buf, 0, chunk_size, reinterpret_cast<const jbyte*>(data));
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            LOGE("Could not update tmp_buf with chunk data");
+            return false;
+        }
+
+        // Write the buffer to the output stream
+        env->CallVoidMethod(output_stream, gOutputStream_write, tmp_buf, 0, chunk_size);
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            LOGE("Could not write buffer to output stream");
+            return false;
+        }
+
+        size -= chunk_size;
+        data += chunk_size;
+    }
+
+    return true;
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_eu_kanade_tachiyomi_data_encoder_WebpEncoder_nativeEncode(JNIEnv* env, jclass type,
+                                                               jbyteArray rgba, jint width,
+                                                               jint height, jint stride,
+                                                               jboolean opaque, jboolean lossless,
+                                                               jobject output_stream) {
+
+    // Initialize webp config with appropriate preset and quality / level
+    WebPConfig webp_config;
+    if (!WebPConfigPreset(&webp_config, WEBP_PRESET_DRAWING, LOSSY_QUALITY)) {
+        LOGE("WebPConfigPreset failed");
+        return false;
+    }
+
+    if (lossless && !WebPConfigLosslessPreset(&webp_config, LOSSLESS_LEVEL)) {
+        LOGE("WebPConfigLosslessPreset failed");
+        return false;
+    }
+
+    // Initialize webp picture with writer callback and context struct
+    WebPPicture pic;
+    WebPPictureInit(&pic);
+    pic.width = width;
+    pic.height = height;
+    pic.writer = webp_write_callback;
+
+    jbyteArray tmp_buf = env->NewByteArray(STORAGE_BUF_SIZE);
+    if (tmp_buf == nullptr) {
+        LOGE("Could not allocate byteArray of size %d", STORAGE_BUF_SIZE);
+        return false;
+    }
+
+    struct encode_context ctx = { env, tmp_buf, output_stream };
+    pic.custom_ptr = (void*) &ctx;
+
+    // WebP recommends lossy encodes use YUV instead of RGB
+    if (lossless) {
+        pic.use_argb = 1;
+    } else {
+        pic.use_argb = 0;
+    }
+
+    if (!WebPValidateConfig(&webp_config)) {
+        LOGE("WebPValidateConfig failed");
+        return false;
+    }
+
+    const jbyte* srcBytes = env->GetByteArrayElements(rgba, NULL);
+    const uint8_t* src = (uint8_t*) srcBytes;
+
+    // Import the bitmap into a webp picture
+    int (*pictureImport)(WebPPicture*, const uint8_t*, int) = nullptr;
+    if (opaque) {
+        pictureImport = WebPPictureImportRGBX;
+    } else {
+        pictureImport = WebPPictureImportRGBA;
+    }
+
+    if (!pictureImport(&pic, src, stride)) {
+        LOGE("pictureImport failed");
+        return false;
+    }
+
+    // Encode the webp
+    if (!WebPEncode(&webp_config, &pic)) {
+        LOGE("WebPEncode failed");
+        WebPPictureFree(&pic);
+        return false;
+    }
+
+    WebPPictureFree(&pic);
+    return true;
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,8 +222,9 @@
     <string name="pref_download_only_over_wifi">Only download over Wi-Fi</string>
     <string name="pref_convert_lossless_downloads">Convert lossless images on download</string>
     <string name="disabled">Disabled</string>
-    <string name="lossless_webp">Lossless WebP (fastest, small, highest quality)</string>
+    <string name="lossless_webp">Lossless WebP (faster, small, highest quality)</string>
     <string name="lossy_webp">Lossy WebP (fast, smallest, high quality)</string>
+    <string name="jpg">JPG (fastest, smaller, mid quality)</string>
     <string name="pref_remove_after_marked_as_read">Remove when marked as read</string>
     <string name="pref_remove_after_read">Remove after read</string>
     <string name="custom_dir">Custom directory</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,10 +220,13 @@
       <!-- Downloads section -->
     <string name="pref_download_directory">Downloads directory</string>
     <string name="pref_download_only_over_wifi">Only download over Wi-Fi</string>
+    <string name="pref_convert_lossless_downloads">Convert lossless images on download</string>
+    <string name="disabled">Disabled</string>
+    <string name="lossless_webp">Lossless WebP (fastest, small, highest quality)</string>
+    <string name="lossy_webp">Lossy WebP (fast, smallest, high quality)</string>
     <string name="pref_remove_after_marked_as_read">Remove when marked as read</string>
     <string name="pref_remove_after_read">Remove after read</string>
     <string name="custom_dir">Custom directory</string>
-    <string name="disabled">Disabled</string>
     <string name="last_read_chapter">Last read chapter</string>
     <string name="second_to_last">Second to last chapter</string>
     <string name="third_to_last">Third to last chapter</string>


### PR DESCRIPTION
This PR implements image conversion for downloaded lossless images (PNG) to save disk space. Currently these images can be converted to lossless WebP, lossy WebP, and JPG images. It is still a WIP, but I am looking for preliminary feedback on the idea in general.

### Testing
 1. Enable conversion by setting `Settings > Downloads > Convert lossless images` to either `Lossy WebP`, `Lossless WebP`, or `JPG`.
2. Change the image decoder to support WebP 1.0.0 by changing `Settings > Reader > Image Decoder` to something other than `Image`.
3. Download manga containing PNGs

### TODO
- Move conversion to separate computation scheduler, perform async / simultaneously with download
- Add some sort of UI to demonstrate conversion is taking place
- ~Add conversion to JPG for what will likely be the fastest, medium size, but worst quality option (using either bitmap.compress~ or libjpeg-turbo)
- Allow the user to specify quality / level, though this may just complicate things from a user perspective
- Split off image encoder to a separate library (I may save this till the end of the PR)
- Move image decoding into native code (remove usage of BitmapFactory.decodeFile)
- Add support for per-scanline encoding of JPEGs (and investigate if WebP can be used similarly)
 - Add support for per-scanline decoding of PNGs and BMP (to have data to take advantage of per-scanline encoding)


### Performance
Performance was measured on a Samsung S6, CPU: Samsung Exynos 7 Octa 7420 (ARMv8a). `encode` is the measure of time spent in native code converting the image, `decodeFile` is the amount of time spent decoding the png file to a bitmap (should be consistent across options). `networkFetch` is the highly variable time spent downloading files, and is only included to give a sense of time-scale.


#### Bakemonogatari - MangaDex EN - Ch 1 - 11: 348 pngs
```
no encoding / purely download: 264MB / 269,876 KB
    Total download took 1:34.450 (94,450,620,877 ns)
        networkFetch took 1:34.450 (94,450,620,877 ns)
        
lossless webp (level: 2):  164MB / 168,420 KB
    Total download took 6:22.831 (382,831,388,808 ns)
        networkFetch took 0:48.772 (48,772,694,353 ns)
        decodeFile took 0:17.645 (17,645,892,586 ns)
        encode took 5:15.073 (315,073,945,869 ns)

jpeg (quality: 90): 122 MB / 124,748 KB
    Total download took 6:35.608 (395,608,739,187 ns)
        networkFetch took 5:33.300 (333,300,234,784 ns)
        decodeFile took 0:18.899 (18,899,810,392 ns)
        encode took 0:42.127 (42,127,317,638 ns)

lossy webp (method: 4, quality: 90): 90MB / 92,068 KB
    Total download took 9:49.724 (589,724,662,113 ns)
        networkFetch took 5:43.680 (343,680,778,120 ns)
        decodeFile took 0:18.914 (18,914,821,723 ns)
        encode took 3:45.689 (225,689,611,186 ns)
```

#### A Story About Treating a Female Knight, Who Has Never Been Treated as a Woman, as a Woman - MangaDex EN - Ch 1 - 15: 109 pngs / 4 jpg 
```
no encoding / purely download: 135 MB / 138,100 KB
    Total download took 2:21.808 (141,808,719,651 ns)
        networkFetch took 2:21.808 (141,808,719,651 ns)
        
lossless webp (level: 2): 75 MB / 76,832 KB
    Total download took 1:22.291 (82,291,610,371 ns)
        networkFetch took 0:25.824 (25,824,026,886 ns)
        decodeFile took 0:08.206 (8,206,622,132 ns)
        encode took 0:47.826 (47,826,675,771 ns)

jpg (quality: 90): 61 MB / 62,256 KB
    Total download took 1:19.652 (79,652,391,123 ns)
        networkFetch took 0:53.597 (53,597,012,609 ns)
        decodeFile took 0:08.602 (8,602,771,618 ns)
        encode took 0:17.020 (17,020,906,217 ns)

lossy webp (method: 4, quality: 90): 50 MB / 50,932 KB
    Total download took 2:01.593 (121,593,689,893 ns)
        networkFetch took 0:23.497 (23,497,979,472 ns)
        decodeFile took 0:08.216 (8,216,367,796 ns)
        encode took 1:29.419 (89,419,385,168 ns)
```

#### Kumo Desu ga, Nani ka? - MangaDex EN - Ch 0 - 28.2: 708 pngs / 129 jpg
```
no encoding / purely download:  2.1 GB / 2,298,348 KB
    Total download took 15:22.051 (922,051,045,767 ns)
        networkFetch took 15:21.962 (921,962,802,394 ns)
        
lossless webp (level: 2): 1.0 GB / 1,090,144 KB
    Total download took 19:26.061 (1,166,061,460,766 ns)
        networkFetch took 6:31.277 (391,277,155,602 ns)
        decodeFile took 1:50.972 (110,972,998,758 ns)
        encode took 11:00.152 (660,152,656,156 ns)

jpg (quality: 90): 636 MB / 650,840 KB
    Total download took 22:30.488 (1,350,488,121,515 ns)
        networkFetch took 17:44.774 (1,064,774,269,752 ns)
        decodeFile took 1:52.678 (112,678,854,875 ns)
        encode took 2:50.317 (170,317,844,203 ns)

lossy webp (method: 4, quality: 90): 686 MB / 702,804 KB
    Total download took 28:04.098 (1,684,098,716,428 ns)
        networkFetch took 6:57.981 (417,981,378,575 ns)
        decodeFile took 1:56.623 (116,623,946,390 ns)
        encode took 19:06.095 (1,146,095,713,009 ns)
```