### PR TITLE
ConfigurableSourceFactory can be configured in the same way as…

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/model/Extension.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/model/Extension.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.model
 
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.SourceFactory
 
 sealed class Extension {
 
@@ -16,7 +17,8 @@ sealed class Extension {
                          override val versionCode: Int,
                          val sources: List<Source>,
                          override val lang: String,
-                         val hasUpdate: Boolean = false) : Extension()
+                         val hasUpdate: Boolean = false,
+                         val sourceFactory: SourceFactory?) : Extension()
 
     data class Available(override val name: String,
                          override val pkgName: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSourceFactory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSourceFactory.kt
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.source
+
+import android.support.v7.preference.PreferenceScreen
+
+/**
+ * A factory for creating sources at runtime.
+ */
+interface ConfigurableSourceFactory: SourceFactory {
+    /**
+     * Create a new copy of the sources
+     * @return The created sources
+     */
+    fun setupPreferenceScreen(screen: PreferenceScreen)
+}


### PR DESCRIPTION
…ConfigurableSource, enabling use-cases where the list of sources produced by the factory depends from user input.

Here is an example where the `SourceFactory` will produce multiple sources from a list of comma-separated values:
![Screenshot_1567169007](https://user-images.githubusercontent.com/2139133/64027025-7cae0380-cb72-11e9-9165-ae04a6e47605.png)
![Screenshot_1567169041](https://user-images.githubusercontent.com/2139133/64027027-7d469a00-cb72-11e9-86b4-e6105f201cde.png)
![Screenshot_1567169074](https://user-images.githubusercontent.com/2139133/64027028-7d469a00-cb72-11e9-9829-02a70e9ec983.png)
