### PR TITLE
Fix #1770

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
+import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import uy.kohesive.injekt.injectLazy
@@ -62,6 +63,9 @@ class DownloadProvider(private val context: Context) {
      * @param source the source to query.
      */
     fun findSourceDir(source: Source): UniFile? {
+        if (source is LocalSource) {
+            return UniFile.fromFile(source.getBaseDirectory())
+        }
         return downloadsDir.findFile(getSourceDirName(source))
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -183,6 +183,10 @@ class LocalSource(private val context: Context) : CatalogueSource {
         return extension.toLowerCase() in setOf("zip", "rar", "cbr", "cbz", "epub")
     }
 
+    fun getBaseDirectory(): File? {
+        return getBaseDirectories(context).firstOrNull()
+    }
+
     fun getFormat(chapter: SChapter): Format {
         val baseDirs = getBaseDirectories(context)
 


### PR DESCRIPTION
Adds a special case for `LocalSource` inside `findSourceDir` so it uses the correct path.

See [my comment on the issue](https://github.com/inorichi/tachiyomi/issues/1770#issuecomment-592994791) for more information.