### PR TITLE
Using the "android-gif-drawable" library to improve the GIF's FPS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -204,6 +204,9 @@ dependencies {
     kapt "com.github.bumptech.glide:compiler:$glide_version"
     implementation 'jp.wasabeef:glide-transformations:4.1.0'
 
+    //GIF Drawable
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.19'
+
     // Logging
     implementation 'com.jakewharton.timber:timber:4.7.1'
 


### PR DESCRIPTION
I have a problem with GIFs(they are way too laggy, I don't know if this is a phone problem). I switched from the Glide's GifDrawable to the "[android-gif-drawable](https://github.com/koral--/android-gif-drawable)" library and this fixed the GIF problem for me. 

I guess it's not the best solution, but at least the GIFs are playing smooth now