### PR TITLE
Stats - total manga by status and source

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
@@ -80,7 +80,7 @@ class MoreController :
         preferenceCategory {
             preference {
                 titleRes = R.string.label_stats
-                iconRes = R.drawable.ic_format_list_bulleted_black_24dp
+                iconRes = R.drawable.ic_insert_chart_black_24dp
                 iconTint = tintColor
                 onClick {
                     router.pushController(StatsMainController().withFadeTransaction())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
@@ -79,6 +79,14 @@ class MoreController :
 
         preferenceCategory {
             preference {
+                titleRes = R.string.label_stats
+                iconRes = R.drawable.ic_format_list_bulleted_black_24dp
+                iconTint = tintColor
+                onClick {
+                    router.pushController(StatsMainController().withFadeTransaction())
+                }
+            }
+            preference {
                 titleRes = R.string.label_settings
                 iconRes = R.drawable.ic_settings_24dp
                 iconTint = tintColor

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/StatsCategoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/StatsCategoryController.kt
@@ -1,0 +1,57 @@
+package eu.kanade.tachiyomi.ui.more
+
+import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.ui.more.StatsMainController.Companion.StatusCounts
+import eu.kanade.tachiyomi.ui.more.StatsMainController.Companion.buildSourceStatusMap
+import eu.kanade.tachiyomi.ui.more.StatsMainController.Companion.sourceStatusSummary
+import eu.kanade.tachiyomi.ui.more.StatsMainController.Companion.topGenres
+import eu.kanade.tachiyomi.ui.more.StatsMainController.Companion.totalManga
+import eu.kanade.tachiyomi.ui.setting.SettingsController
+import eu.kanade.tachiyomi.util.preference.preference
+import eu.kanade.tachiyomi.util.preference.preferenceCategory
+import eu.kanade.tachiyomi.util.preference.titleRes
+
+class StatsCategoryController(
+    private val categoryMangasMap: Map<String?, Set<Manga>> = emptyMap(),
+    private val longNameMap: Map<Long, String> = emptyMap(),
+    private val categoryGenresMap: MutableMap<String?, MutableMap<String, Int>> = mutableMapOf(),
+    private val overallGenresMap: MutableMap<String, Int> = mutableMapOf()
+) : SettingsController() {
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) = with(screen) {
+        titleRes = R.string.stats_category_breakdown
+
+        preference {
+            titleRes = R.string.stats_overall_top_genres
+
+            summary = overallGenresMap.topGenres(20)
+        }
+
+        categoryMangasMap.forEach { catMangasEntry ->
+            val sourceStatusMap = mutableMapOf<String, StatusCounts>()
+            catMangasEntry.value.forEach { manga -> buildSourceStatusMap(manga, sourceStatusMap, longNameMap) }
+
+            preferenceCategory {
+                title = "${catMangasEntry.key ?: context.getString(R.string.default_category)} : ${sourceStatusSummary(totalManga(sourceStatusMap), context)}"
+
+                preference {
+                    titleRes = R.string.stats_genres_overview
+
+                    summary = categoryGenresMap[catMangasEntry.key]!!.topGenres(5)
+                }
+
+                sourceStatusMap.entries
+                    .sortedByDescending { it.value.total }
+                    .forEach { sourceStatusEntry ->
+                        preference {
+                            title = sourceStatusEntry.key
+
+                            summary = sourceStatusSummary(sourceStatusEntry.value, context)
+                        }
+                    }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/StatsMainController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/StatsMainController.kt
@@ -1,0 +1,86 @@
+package eu.kanade.tachiyomi.ui.more
+
+import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.source.SourceManager
+import eu.kanade.tachiyomi.ui.setting.SettingsController
+import eu.kanade.tachiyomi.util.preference.preference
+import eu.kanade.tachiyomi.util.preference.preferenceCategory
+import eu.kanade.tachiyomi.util.preference.titleRes
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
+
+class StatsMainController : SettingsController() {
+    private val db: DatabaseHelper = Injekt.get()
+    // Needed to get names for source IDs
+    internal val sourceManager: SourceManager by injectLazy()
+    // Favorited manga
+    private val faves = db.getFavoriteMangas().executeAsBlocking()
+
+    private data class StatusCounts(var ongoing: Int = 0, var completed: Int = 0, var unknown: Int = 0, var licensed: Int = 0, var total: Int = 0)
+    @Suppress("MapGetWithNotNullAssertionOperator")
+    private val sourceStatusMap by lazy {
+        val ssMap = mutableMapOf<Long, StatusCounts>()
+        faves.forEach { manga ->
+            if (manga.source !in ssMap.keys) ssMap[manga.source] = StatusCounts()
+            when (manga.status) {
+                1 -> ssMap[manga.source]!!.ongoing++
+                2 -> ssMap[manga.source]!!.completed++
+                3 -> ssMap[manga.source]!!.licensed++
+                else -> ssMap[manga.source]!!.unknown++
+            }
+            ssMap[manga.source]!!.total++
+        }
+        val idNameMap = ssMap.keys
+            .map { Pair(it, sourceManager.get(it)?.name ?: it.toString()) }
+            .toMap()
+        ssMap.keys
+            .map { Pair(it, ssMap[it]!!.total) } // id, total manga
+            .sortedByDescending { it.second } // sort by totals
+            .map { it.first } // sorted keys
+            .map { Pair(idNameMap[it]!!, ssMap[it]!!) } // build a sorted collection with source names
+            .toMap()
+    }
+
+    @Suppress("MapGetWithNotNullAssertionOperator")
+    private fun totalManga(): StatusCounts {
+        val totals = StatusCounts()
+        sourceStatusMap.keys.forEach { key -> totals.ongoing += sourceStatusMap[key]!!.ongoing }
+        sourceStatusMap.keys.forEach { key -> totals.completed += sourceStatusMap[key]!!.completed }
+        sourceStatusMap.keys.forEach { key -> totals.unknown += sourceStatusMap[key]!!.unknown }
+        sourceStatusMap.keys.forEach { key -> totals.licensed += sourceStatusMap[key]!!.licensed }
+        sourceStatusMap.keys.forEach { key -> totals.total += sourceStatusMap[key]!!.total }
+        return totals
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) = with(screen) {
+        titleRes = R.string.label_stats
+
+        preference {
+            titleRes = R.string.stats_status_totals
+
+            val totals = totalManga()
+            summary = "${totals.total} ${context.getString(R.string.stats_total)} | ${totals.ongoing} ${context.getString(R.string.ongoing)}" +
+                " | ${totals.unknown} ${context.getString(R.string.unknown)} | ${totals.completed} ${context.getString(R.string.completed)}" +
+                " | ${totals.licensed} ${context.getString(R.string.licensed)}"
+        }
+
+        preferenceCategory {
+            titleRes = R.string.stats_source_status_totals
+            summary = "${context.getString(R.string.stats_sources_with_faves)}: ${sourceStatusMap.count()}"
+
+            sourceStatusMap.forEach { mapEntry ->
+                preference {
+                    title = mapEntry.key
+
+                    val totals = mapEntry.value
+                    summary = "${totals.total} ${context.getString(R.string.stats_total)} | ${totals.ongoing} ${context.getString(R.string.ongoing)}" +
+                        " | ${totals.unknown} ${context.getString(R.string.unknown)} | ${totals.completed} ${context.getString(R.string.completed)}" +
+                        " | ${totals.licensed} ${context.getString(R.string.licensed)}"
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_format_list_bulleted_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_format_list_bulleted_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_format_list_bulleted_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_format_list_bulleted_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_insert_chart_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_insert_chart_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM9,17L7,17v-7h2v7zM13,17h-2L11,7h2v10zM17,17h-2v-4h2v4z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
 
     <!-- Activities and fragments labels (toolbar title) -->
     <string name="label_more">More</string>
-    <string name="label_stats">Stats</string>
+    <string name="label_stats">Statistics</string>
     <string name="label_settings">Settings</string>
     <string name="label_download_queue">Download queue</string>
     <string name="label_library">Library</string>
@@ -653,9 +653,13 @@
 
     <!-- Stats -->
     <string name="stats_total">Total</string>
-    <string name="stats_status_totals">Total Manga By Status</string>
-    <string name="stats_source_status_totals">Status Breakdown By Source</string>
+    <string name="stats_status_totals">Total manga by status</string>
+    <string name="stats_source_status_totals">Status breakdown by source</string>
     <string name="stats_sources_with_faves">Number of sources with favorited manga</string>
+    <string name="stats_category_breakdown">Category breakdown</string>
+    <string name="stats_manga_per_category">Manga per category</string>
+    <string name="stats_genres_overview">Top genres</string>
+    <string name="stats_overall_top_genres">Overall top genres</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -655,7 +655,7 @@
     <string name="stats_total">Total</string>
     <string name="stats_status_totals">Total Manga By Status</string>
     <string name="stats_source_status_totals">Status Breakdown By Source</string>
-    <string name="stats_sources_with_faves">Number of sources with bookmarked manga</string>
+    <string name="stats_sources_with_faves">Number of sources with favorited manga</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
     <!-- Activities and fragments labels (toolbar title) -->
     <string name="label_more">More</string>
+    <string name="label_stats">Stats</string>
     <string name="label_settings">Settings</string>
     <string name="label_download_queue">Download queue</string>
     <string name="label_library">Library</string>
@@ -649,5 +650,12 @@
     <string name="channel_backup_restore">Backup and restore</string>
     <string name="channel_backup_restore_progress">Progress</string>
     <string name="channel_backup_restore_complete">Complete</string>
+
+    <!-- Stats -->
+    <string name="stats_total">Total</string>
+    <string name="stats_status_totals">Total Manga By Status</string>
+    <string name="stats_source_status_totals">Status Breakdown By Source</string>
+    <string name="stats_sources_with_faves">Number of sources with bookmarked manga</string>
+
 
 </resources>


### PR DESCRIPTION
Adds a simple stats page with a total manga count, number of manga per status, and a breakdown of the same per source.

![Screenshot_1589678273](https://user-images.githubusercontent.com/51273546/82134859-63b1b500-97ca-11ea-8d35-b7fdc9434172.png)
