### PR TITLE
Enable manga blocker

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/ParsedHttpSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/ParsedHttpSource.kt
@@ -24,7 +24,7 @@ abstract class ParsedHttpSource : HttpSource() {
 
         val mangas = document.select(popularMangaSelector()).map { element ->
             popularMangaFromElement(element)
-        }
+        }.filter { manga -> manga.title != "REMOVEDMANGA" }
 
         val hasNextPage = popularMangaNextPageSelector()?.let { selector ->
             document.select(selector).first()
@@ -62,7 +62,7 @@ abstract class ParsedHttpSource : HttpSource() {
 
         val mangas = document.select(searchMangaSelector()).map { element ->
             searchMangaFromElement(element)
-        }
+        }.filter { manga -> manga.title != "REMOVEDMANGA" }
 
         val hasNextPage = searchMangaNextPageSelector()?.let { selector ->
             document.select(selector).first()
@@ -100,7 +100,7 @@ abstract class ParsedHttpSource : HttpSource() {
 
         val mangas = document.select(latestUpdatesSelector()).map { element ->
             latestUpdatesFromElement(element)
-        }
+        }.filter { manga -> manga.title != "REMOVEDMANGA" }
 
         val hasNextPage = latestUpdatesNextPageSelector()?.let { selector ->
             document.select(selector).first()


### PR DESCRIPTION
Because so many sites do not have a filter option, this commit will help extension archive a manga blocker in popular, latest and search result. Extension can set manga's title to "REMOVEDMANGA" and indicates APP to drop it.


One possible scenario is that users edit their blocklist keywords in extension preference panel, and the extension can compare these keywords with manga's genre or title; If any matches, rename its title to "REMOVEDMANGA".