### PR TITLE
Direct user back to global search when coming from source search results

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
@@ -35,6 +35,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.base.controller.FabController
 import eu.kanade.tachiyomi.ui.base.controller.NucleusController
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchController
 import eu.kanade.tachiyomi.ui.library.ChangeMangaCategoriesDialog
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaController
@@ -279,7 +280,12 @@ open class BrowseSourceController(bundle: Bundle) :
         searchItem.fixExpand(
             onExpand = { invalidateMenuOnExpand() },
             onCollapse = {
-                searchWithQuery("")
+                if (router.backstackSize >= 2 && router.backstack[router.backstackSize - 2].controller() is GlobalSearchController) {
+                    router.popController(this)
+                } else {
+                    searchWithQuery("")
+                }
+
                 true
             }
         )


### PR DESCRIPTION
## Setup:
Browse or Library -> Global Search -> Source Search Results
1. Trigger global text search (from Browse, Library or anywhere else).
2. Press source name to view more results from that source.
3. Press back button.

## Expected:
Browse or Library <- Global Search <- Source Search Results
It's more natural to expect the back button in step 3 to direct user back to global search.

## Actual:
Browse or Library <- Global Search <- Source Page <- Source Search Results
Back button clears the search text, directing user to source's default page.
This inconveniences the user to press back twice just to go back to the global search results.
