### PR TITLE
Fix Kitsu toasting "Logged in" when there is an error

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -101,14 +101,10 @@ class Kitsu(private val context: Context, id: Int) : TrackService(id) {
     }
 
     override suspend fun login(username: String, password: String) {
-        try {
-            val token = api.login(username, password)
-            interceptor.newAuth(token)
-            val userId = api.getCurrentUser()
-            saveCredentials(username, userId)
-        } catch (e: Throwable) {
-            logout()
-        }
+        val token = api.login(username, password)
+        interceptor.newAuth(token)
+        val userId = api.getCurrentUser()
+        saveCredentials(username, userId)
     }
 
     override fun logout() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginDialog.kt
@@ -48,6 +48,7 @@ class TrackLoginDialog(
                 dialog?.dismiss()
                 withUIContext { view?.context?.toast(R.string.login_success) }
             } catch (e: Throwable) {
+                service.logout()
                 binding?.login?.progress = -1
                 binding?.login?.setText(R.string.unknown_error)
                 withUIContext { e.message?.let { view?.context?.toast(it) } }


### PR DESCRIPTION
Fixes #4324

Currently, if you input the wrong credentials when login into Kitsu (tracker) it will count as a successful login.

This is solved by removing the try/catch in `Kitsu` and handling the exception in `TrackLoginDialog` instead