### PR TITLE
Match color for download, header, and pin buttons

### DIFF
--- a/app/src/main/res/color/button_action_selector.xml
+++ b/app/src/main/res/color/button_action_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="?attr/colorAccent" android:state_activated="true" />
-    <item android:color="?android:attr/textColorSecondary" android:state_activated="false" />
+    <item android:color="?android:attr/textColorHint" android:state_activated="false" />
 </selector>

--- a/app/src/main/res/layout/chapter_download_view.xml
+++ b/app/src/main/res/layout/chapter_download_view.xml
@@ -14,7 +14,7 @@
         android:padding="2dp"
         android:scaleType="fitXY"
         app:srcCompat="@drawable/border_circle"
-        app:tint="@color/material_on_surface_emphasis_medium"
+        app:tint="?android:attr/textColorHint"
         tools:ignore="ContentDescription" />
 
     <ImageView
@@ -24,7 +24,7 @@
         android:padding="4dp"
         android:scaleType="fitXY"
         app:srcCompat="@drawable/ic_arrow_downward_24dp"
-        app:tint="@color/material_on_surface_emphasis_medium"
+        app:tint="?android:attr/textColorHint"
         tools:ignore="ContentDescription" />
 
     <com.google.android.material.progressindicator.CircularProgressIndicator
@@ -34,7 +34,7 @@
         android:indeterminate="true"
         android:padding="1dp"
         android:visibility="gone"
-        app:indicatorColor="@color/material_on_surface_emphasis_medium"
+        app:indicatorColor="?android:attr/textColorHint"
         app:indicatorInset="0dp"
         app:indicatorSize="24dp"
         app:trackThickness="2dp" />


### PR DESCRIPTION
Anaheim pointed out on Discord that the download button uses a different color from the pin button, this fixes that
https://discord.com/channels/349436576037732353/694092459839455243/802124365524893716

Anaheim also pointed out that it probably the same case for buttons in the manga info header. But I'm unsure if they should be the same color as the download button and pin color
https://discord.com/channels/349436576037732353/694092459839455243/802133314688778280

| Before ||
|---|---|
| ![Screenshot_1611316057](https://user-images.githubusercontent.com/6576096/105487222-069ec500-5cb0-11eb-8597-7bca5d7871fa.png) | ![Screenshot_1611316063](https://user-images.githubusercontent.com/6576096/105487229-09011f00-5cb0-11eb-80dd-047645a31ab9.png) |
| Header buttons: hsl(0, 0%, 45%) <br> Download button: hsl(0, 0%, 47%) | Pin: hsl(0, 0%, 61%) |

| After ||
|---|---|
| ![Screenshot_1611315862](https://user-images.githubusercontent.com/6576096/105486987-b45da400-5caf-11eb-90a6-457b281687b5.png) | ![Screenshot_1611315880](https://user-images.githubusercontent.com/6576096/105486996-b7f12b00-5caf-11eb-9843-749d37bbd2ec.png) |