### PR TITLE
Fix UpdateCategories dialog to not remove old value

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
@@ -613,7 +613,7 @@ open class BrowseSourceController(bundle: Bundle) :
      * @param mangas The list of manga to move to categories.
      * @param categories The list of categories where manga will be placed.
      */
-    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>) {
+    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>, preselected: List<Category>) {
         val manga = mangas.firstOrNull() ?: return
 
         presenter.changeMangaFavorite(manga)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
@@ -40,13 +40,14 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
                 allowEmptySelection = true
             ) { _, selections, _ ->
                 val newCategories = selections.map { categories[it] }
-                (targetController as? Listener)?.updateCategoriesForMangas(mangas, newCategories)
+                val preselectedCategories = preselected.map { categories[it] }
+                (targetController as? Listener)?.updateCategoriesForMangas(mangas, newCategories, preselectedCategories)
             }
             .positiveButton(android.R.string.ok)
             .negativeButton(android.R.string.cancel)
     }
 
     interface Listener {
-        fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>)
+        fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>, preselected: List<Category> = emptyList<Category>())
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -561,8 +561,8 @@ class LibraryController(
         DeleteLibraryMangasDialog(this, selectedMangas.toList()).showDialog(router)
     }
 
-    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>) {
-        presenter.moveMangasToCategories(categories, mangas)
+    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>, preselected: List<Category>) {
+        presenter.updateMangasToCategories(categories, mangas, preselected)
         destroyActionModeIfNeeded()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -461,10 +461,10 @@ class LibraryPresenter(
      * @param mangas the list of manga to move.
      * @param oldCommon the list of common categories pre-update
      */
-    fun updateMangasToCategories(newCategories: List<Category>, mangas: List<Manga>, oldCommon: List<Category> = emptyList<Category>()) {
+    fun updateMangasToCategories(newCommon: List<Category>, mangas: List<Manga>, oldCommon: List<Category> = emptyList<Category>()) {
         val mc = mutableListOf<MangaCategory>()
-        val removedCategories = oldCommon.filter { !newCategories.contains(it) }
-        val addedCategories = newCategories.filter { !oldCommon.contains(it) }
+        val removedCategories = oldCommon.filter { !newCommon.contains(it) }
+        val addedCategories = newCommon.filter { !oldCommon.contains(it) }
         for (manga in mangas) {
             val newCategories = db.getCategoriesForManga(manga).executeAsBlocking().filter { !removedCategories.contains(it) }.plus(addedCategories)
             newCategories.mapTo(mc) { MangaCategory.create(manga, it) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -453,4 +453,23 @@ class LibraryPresenter(
 
         db.setMangaCategories(mc, mangas)
     }
+
+    /**
+     * Bulk update categories of mangas using old and new common categories.
+     *
+     * @param newCategories the selected categories.
+     * @param mangas the list of manga to move.
+     * @param oldCommon the list of common categories pre-update
+     */
+    fun updateMangasToCategories(newCategories: List<Category>, mangas: List<Manga>, oldCommon: List<Category> = emptyList<Category>()) {
+        val mc = mutableListOf<MangaCategory>()
+        val removedCategories = oldCommon.filter { !newCategories.contains(it) }
+        val addedCategories = newCategories.filter { !oldCommon.contains(it) }
+        for (manga in mangas) {
+            val newCategories = db.getCategoriesForManga(manga).executeAsBlocking().filter { !removedCategories.contains(it) }.plus(addedCategories)
+            newCategories.mapTo(mc) { MangaCategory.create(manga, it) }
+        }
+
+        db.setMangaCategories(mc, mangas)
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -457,7 +457,7 @@ class LibraryPresenter(
     /**
      * Bulk update categories of mangas using old and new common categories.
      *
-     * @param newCategories the selected categories.
+     * @param newCommon the selected categories.
      * @param mangas the list of manga to move.
      * @param oldCommon the list of common categories pre-update
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -527,7 +527,7 @@ class MangaController :
             .showDialog(router)
     }
 
-    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>) {
+    override fun updateCategoriesForMangas(mangas: List<Manga>, categories: List<Category>, preselected: List<Category>) {
         val manga = mangas.firstOrNull() ?: return
 
         if (!manga.favorite) {


### PR DESCRIPTION
Fix https://github.com/tachiyomiorg/tachiyomi/issues/961
Add preselected to updateCategoriesForMangas listener as reference
Add updateMangasToCategories that bulk update categories of mangas using
    old and new common categories

Signed-off-by: Quang Kieu <quangkieu1993@gmail.com>