### PR TITLE
Unify history and update item

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
@@ -68,9 +68,8 @@ class HistoryHolder(
             binding.mangaSubtitle.text = Date(history.last_read).toTimestampString()
         }
 
-        val requestOptions = RequestOptions().apply {
-            transform(CenterCrop(), RoundedCorners(8))
-        }
+        val radius = itemView.context.resources.getDimensionPixelSize(R.dimen.card_radius)
+        val requestOptions = RequestOptions().transform(CenterCrop(), RoundedCorners(radius))
 
         // Set cover
         GlideApp.with(itemView.context).clear(binding.cover)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
@@ -2,6 +2,9 @@ package eu.kanade.tachiyomi.ui.recent.history
 
 import android.view.View
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.bumptech.glide.request.RequestOptions
 import eu.davidea.viewholders.FlexibleViewHolder
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.MangaChapterHistory
@@ -65,12 +68,16 @@ class HistoryHolder(
             binding.mangaSubtitle.text = Date(history.last_read).toTimestampString()
         }
 
+        val requestOptions = RequestOptions().apply {
+            transform(CenterCrop(), RoundedCorners(8))
+        }
+
         // Set cover
         GlideApp.with(itemView.context).clear(binding.cover)
         GlideApp.with(itemView.context)
             .load(manga.toMangaThumbnail())
             .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
-            .centerCrop()
+            .apply(requestOptions)
             .into(binding.cover)
     }
 }

--- a/app/src/main/res/layout/history_item.xml
+++ b/app/src/main/res/layout/history_item.xml
@@ -1,84 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/holder"
-    style="@style/Theme.Widget.CardView.Item"
-    android:padding="0dp">
+    android:layout_width="match_parent"
+    android:layout_height="80dp"
+    android:layout_marginStart="16dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="8dp"
+    android:orientation="horizontal">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:orientation="horizontal">
+    <ImageView
+        android:id="@+id/cover"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/description_cover"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="h,3:2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@mipmap/ic_launcher" />
 
-        <ImageView
-            android:id="@+id/cover"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:contentDescription="@string/description_cover"
-            android:scaleType="centerCrop"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintDimensionRatio="h,3:2"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@mipmap/ic_launcher" />
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="8dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/remove"
+        app:layout_constraintStart_toEndOf="@+id/cover"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <LinearLayout
-            android:layout_width="0dp"
+        <TextView
+            android:id="@+id/manga_title"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="8dp"
-            android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/remove"
-            app:layout_constraintStart_toEndOf="@+id/cover"
-            app:layout_constraintTop_toTopOf="parent">
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="@style/TextAppearance.Medium"
+            tools:text="Title" />
 
-            <TextView
-                android:id="@+id/manga_title"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:maxLines="2"
-                android:textAppearance="@style/TextAppearance.Medium"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/manga_subtitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                tools:text="Subtitle" />
-
-        </LinearLayout>
-
-        <ImageButton
-            android:id="@+id/remove"
-            android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/manga_subtitle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?selectableItemBackgroundBorderless"
-            android:contentDescription="@string/action_resume"
-            android:padding="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/resume"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_delete_24dp"
-            app:tint="?android:attr/textColorPrimary" />
+            android:layout_marginTop="4dp"
+            tools:text="Subtitle" />
 
-        <ImageButton
-            android:id="@+id/resume"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:background="?selectableItemBackgroundBorderless"
-            android:contentDescription="@string/action_resume"
-            android:padding="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_play_arrow_24dp"
-            app:tint="?android:attr/textColorPrimary" />
+    </LinearLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <ImageButton
+        android:id="@+id/remove"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackgroundBorderless"
+        android:contentDescription="@string/action_resume"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/resume"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_delete_24dp"
+        app:tint="?android:attr/textColorPrimary" />
 
-</androidx.cardview.widget.CardView>
+    <ImageButton
+        android:id="@+id/resume"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackgroundBorderless"
+        android:contentDescription="@string/action_resume"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_play_arrow_24dp"
+        app:tint="?android:attr/textColorPrimary" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/updates_item.xml
+++ b/app/src/main/res/layout/updates_item.xml
@@ -9,13 +9,13 @@
 
     <ImageView
         android:id="@+id/manga_cover"
-        android:layout_width="56dp"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:paddingStart="16dp"
-        android:paddingTop="8dp"
-        android:paddingEnd="0dp"
-        android:paddingBottom="8dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="h,1:1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@mipmap/ic_launcher" />
@@ -27,7 +27,7 @@
         android:layout_marginStart="16dp"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textAppearance="@style/TextAppearance.Regular.Body1"
+        android:textAppearance="@style/TextAppearance.Medium.Body2"
         app:layout_constraintBottom_toTopOf="@+id/chapter_title"
         app:layout_constraintEnd_toStartOf="@+id/download"
         app:layout_constraintStart_toEndOf="@+id/manga_cover"


### PR DESCRIPTION
It has annoyed me that history uses card background while updates don't. So this makes history and update item look more the same. 

| Updates | History | [Not in PR] History but with grey tinted ImageButtons |
|---|---|---|
| ![Screenshot_1611749515](https://user-images.githubusercontent.com/6576096/105989780-e2712880-60a1-11eb-8ea1-59afba72860f.png) | ![Screenshot_1611749512](https://user-images.githubusercontent.com/6576096/105989769-e00ece80-60a1-11eb-9b41-265fe85051e3.png) | ![Screenshot_1611749488](https://user-images.githubusercontent.com/6576096/105989755-dc7b4780-60a1-11eb-9ba2-560494bad8c1.png) |
| Title is now bold | Removed card background | I thought this looks weird, that why I didn't include it. But would match ImageButton tint on other screens |