### PR TITLE
Dual page split allow to have different setting for Paged and Webtoon

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -23,9 +23,13 @@ object PreferenceKeys {
 
     const val showPageNumber = "pref_show_page_number_key"
 
-    const val dualPageSplit = "pref_dual_page_split"
+    const val dualPageSplitPaged = "pref_dual_page_split"
 
-    const val dualPageInvert = "pref_dual_page_invert"
+    const val dualPageSplitWebtoon = "pref_dual_page_split_webtoon"
+
+    const val dualPageInvertPaged = "pref_dual_page_invert"
+
+    const val dualPageInvertWebtoon = "pref_dual_page_invert_webtoon"
 
     const val showReadingMode = "pref_show_reading_mode"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -89,9 +89,13 @@ class PreferencesHelper(val context: Context) {
 
     fun showPageNumber() = flowPrefs.getBoolean(Keys.showPageNumber, true)
 
-    fun dualPageSplit() = flowPrefs.getBoolean(Keys.dualPageSplit, false)
+    fun dualPageSplitPaged() = flowPrefs.getBoolean(Keys.dualPageSplitPaged, false)
 
-    fun dualPageInvert() = flowPrefs.getBoolean(Keys.dualPageInvert, false)
+    fun dualPageSplitWebtoon() = flowPrefs.getBoolean(Keys.dualPageSplitWebtoon, false)
+
+    fun dualPageInvertPaged() = flowPrefs.getBoolean(Keys.dualPageInvertPaged, false)
+
+    fun dualPageInvertWebtoon() = flowPrefs.getBoolean(Keys.dualPageInvertWebtoon, false)
 
     fun showReadingMode() = prefs.getBoolean(Keys.showReadingMode, true)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
@@ -68,17 +68,10 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BaseBottomShee
         binding.backgroundColor.bindToIntPreference(preferences.readerTheme(), R.array.reader_themes_values)
         binding.showPageNumber.bindToPreference(preferences.showPageNumber())
         binding.fullscreen.bindToPreference(preferences.fullscreen())
-        binding.dualPageSplit.bindToPreference(preferences.dualPageSplit())
         binding.keepscreen.bindToPreference(preferences.keepScreenOn())
         binding.longTap.bindToPreference(preferences.readWithLongTap())
         binding.alwaysShowChapterTransition.bindToPreference(preferences.alwaysShowChapterTransition())
         binding.pageTransitions.bindToPreference(preferences.pageTransitions())
-
-        // Makes so that dual page invert gets hidden away when turning of dual page split
-        preferences.dualPageSplit()
-            .asImmediateFlow { binding.dualPageInvert.isVisible = it }
-            .launchIn(activity.lifecycleScope)
-        binding.dualPageInvert.bindToPreference(preferences.dualPageInvert())
 
         // If the preference is explicitly disabled, that means the setting was configured since there is a cutout
         if (activity.hasCutout || !preferences.cutoutShort().get()) {
@@ -102,6 +95,13 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BaseBottomShee
         binding.pagerPrefsGroup.scaleType.bindToPreference(preferences.imageScaleType(), 1)
         binding.pagerPrefsGroup.zoomStart.bindToPreference(preferences.zoomStart(), 1)
         binding.pagerPrefsGroup.cropBorders.bindToPreference(preferences.cropBorders())
+
+        // Makes so that dual page invert gets hidden away when turning of dual page split
+        binding.dualPageSplit.bindToPreference(preferences.dualPageSplitPaged())
+        preferences.dualPageSplitPaged()
+            .asImmediateFlow { binding.dualPageInvert.isVisible = it }
+            .launchIn(activity.lifecycleScope)
+        binding.dualPageInvert.bindToPreference(preferences.dualPageInvertPaged())
     }
 
     /**
@@ -118,6 +118,13 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BaseBottomShee
         binding.webtoonPrefsGroup.webtoonNav.bindToPreference(preferences.navigationModeWebtoon())
         binding.webtoonPrefsGroup.cropBordersWebtoon.bindToPreference(preferences.cropBordersWebtoon())
         binding.webtoonPrefsGroup.webtoonSidePadding.bindToIntPreference(preferences.webtoonSidePadding(), R.array.webtoon_side_padding_values)
+
+        // Makes so that dual page invert gets hidden away when turning of dual page split
+        binding.dualPageSplit.bindToPreference(preferences.dualPageSplitWebtoon())
+        preferences.dualPageSplitWebtoon()
+            .asImmediateFlow { binding.dualPageInvert.isVisible = it }
+            .launchIn(activity.lifecycleScope)
+        binding.dualPageInvert.bindToPreference(preferences.dualPageInvertWebtoon())
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
@@ -24,9 +24,13 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
     var volumeKeysInverted = false
     var trueColor = false
     var alwaysShowChapterTransition = true
-    var dualPageSplit = false
-    var dualPageInvert = false
     var navigationMode = 0
+        protected set
+
+    var dualPageSplit = false
+        protected set
+
+    var dualPageInvert = false
         protected set
 
     abstract var navigator: ViewerNavigation
@@ -56,12 +60,6 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
 
         preferences.alwaysShowChapterTransition()
             .register({ alwaysShowChapterTransition = it })
-
-        preferences.dualPageSplit()
-            .register({ dualPageSplit = it }, { imagePropertyChangedListener?.invoke() })
-
-        preferences.dualPageInvert()
-            .register({ dualPageInvert = it }, { imagePropertyChangedListener?.invoke() })
     }
 
     protected abstract fun defaultNavigation(): ViewerNavigation

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -44,6 +44,12 @@ class PagerConfig(
 
         preferences.pagerNavInverted()
             .register({ tappingInverted = it }, { navigator.invertMode = it })
+
+        preferences.dualPageSplitPaged()
+            .register({ dualPageSplit = it }, { imagePropertyChangedListener?.invoke() })
+
+        preferences.dualPageInvertPaged()
+            .register({ dualPageInvert = it }, { imagePropertyChangedListener?.invoke() })
     }
 
     private fun zoomTypeFromPreference(value: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -37,6 +37,12 @@ class WebtoonConfig(
 
         preferences.webtoonNavInverted()
             .register({ tappingInverted = it }, { navigator.invertMode = it })
+
+        preferences.dualPageSplitWebtoon()
+            .register({ dualPageSplit = it }, { imagePropertyChangedListener?.invoke() })
+
+        preferences.dualPageInvertWebtoon()
+            .register({ dualPageInvert = it }, { imagePropertyChangedListener?.invoke() })
     }
 
     override var navigator: ViewerNavigation = defaultNavigation()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -50,18 +50,6 @@ class SettingsReaderController : SettingsController() {
             summaryRes = R.string.pref_show_reading_mode_summary
             defaultValue = true
         }
-        switchPreference {
-            key = Keys.dualPageSplit
-            titleRes = R.string.pref_dual_page_split
-            defaultValue = false
-        }
-        switchPreference {
-            key = Keys.dualPageInvert
-            titleRes = R.string.pref_dual_page_invert
-            summaryRes = R.string.pref_dual_page_invert_summary
-            defaultValue = false
-            preferences.dualPageSplit().asImmediateFlow { isVisible = it }.launchIn(viewScope)
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             switchPreference {
                 key = Keys.trueColor
@@ -213,6 +201,18 @@ class SettingsReaderController : SettingsController() {
                 titleRes = R.string.pref_crop_borders
                 defaultValue = false
             }
+            switchPreference {
+                key = Keys.dualPageSplitPaged
+                titleRes = R.string.pref_dual_page_split
+                defaultValue = false
+            }
+            switchPreference {
+                key = Keys.dualPageInvertPaged
+                titleRes = R.string.pref_dual_page_invert
+                summaryRes = R.string.pref_dual_page_invert_summary
+                defaultValue = false
+                preferences.dualPageSplitPaged().asImmediateFlow { isVisible = it }.launchIn(viewScope)
+            }
         }
 
         preferenceCategory {
@@ -267,6 +267,18 @@ class SettingsReaderController : SettingsController() {
                 key = Keys.cropBordersWebtoon
                 titleRes = R.string.pref_crop_borders
                 defaultValue = false
+            }
+            switchPreference {
+                key = Keys.dualPageSplitWebtoon
+                titleRes = R.string.pref_dual_page_split
+                defaultValue = false
+            }
+            switchPreference {
+                key = Keys.dualPageInvertWebtoon
+                titleRes = R.string.pref_dual_page_invert
+                summaryRes = R.string.pref_dual_page_invert_summary
+                defaultValue = false
+                preferences.dualPageSplitWebtoon().asImmediateFlow { isVisible = it }.launchIn(viewScope)
             }
         }
 


### PR DESCRIPTION
closes #4525

This splits dual page split setting from applying to both Paged and Webtoon at the same time. To let users control if both or just one viewer is gonna split the dual paged content