### PR TITLE
Adding Light Rosé (Pink) as a selectable light theme.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -16,6 +16,7 @@ object PreferenceValues {
     enum class LightThemeVariant {
         default,
         blue,
+        rose,
     }
 
     // Keys are lowercase to match legacy string values

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
@@ -25,6 +25,7 @@ abstract class BaseThemedActivity : AppCompatActivity() {
     private val lightTheme: Int by lazy {
         when (preferences.themeLight().get()) {
             Values.LightThemeVariant.blue -> R.style.Theme_Tachiyomi_LightBlue
+            Values.LightThemeVariant.rose -> R.style.Theme_Tachiyomi_LightRose
             else -> {
                 when {
                     // Light status + navigation bar

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -106,11 +106,13 @@ class SettingsGeneralController : SettingsController() {
                 titleRes = R.string.pref_theme_light
                 entriesRes = arrayOf(
                     R.string.theme_light_default,
-                    R.string.theme_light_blue
+                    R.string.theme_light_blue,
+                    R.string.theme_light_rose
                 )
                 entryValues = arrayOf(
                     Values.LightThemeVariant.default.name,
-                    Values.LightThemeVariant.blue.name
+                    Values.LightThemeVariant.blue.name,
+                    Values.LightThemeVariant.rose.name
                 )
                 defaultValue = Values.LightThemeVariant.default.name
                 summary = "%s"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -74,6 +74,10 @@
     <color name="md_blue_grey_900">#263238</color>
     <color name="md_blue_grey_800">#37474F</color>
 
+    <color name="md_pink_200">#F48FB1</color>
+    <color name="md_pink_300">#F06292</color>
+    <color name="md_pink_500">#E91E63</color>
+
     <color name="green">#47a84a</color>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="pref_theme_light">Light theme</string>
     <string name="theme_light_default">Default</string>
     <string name="theme_light_blue">Light blue</string>
+    <string name="theme_light_rose">Light rosé</string>
     <string name="pref_theme_dark">Dark theme</string>
     <string name="theme_dark_default">Default</string>
     <string name="theme_dark_blue">Dark blue</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -103,6 +103,17 @@
         <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
     </style>
 
+    <style name="Theme.Tachiyomi.LightRose" parent="Theme.Base">
+
+        <item name="colorPrimary">@color/md_pink_200</item>
+        <item name="colorOnPrimary">@color/textColorPrimaryDark</item>
+        <item name="colorAccent">@color/md_pink_500</item>
+        <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
+        <item name="colorSecondary">@color/md_pink_500</item>
+        <item name="colorPrimaryVariant">@color/md_pink_300</item>
+        <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
+    </style>
+
     <!--=============-->
     <!-- Dark Themes -->
     <!--=============-->


### PR DESCRIPTION
I thought adding a new color scheme to Tachiyomi might be a pleasant touch.

I used material palette colors to add a Pinkish Light theme variant:

![device-2021-03-09-230843](https://user-images.githubusercontent.com/5253171/110590440-9eefec80-812c-11eb-8def-758360fdf372.png)
![device-2021-03-09-230936](https://user-images.githubusercontent.com/5253171/110590444-a0b9b000-812c-11eb-8191-044a28e50027.png)
![device-2021-03-09-231003](https://user-images.githubusercontent.com/5253171/110590448-a1524680-812c-11eb-9886-1f71352455ab.png)
