### PR TITLE
Update URL for Local Manga guide

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -27,7 +27,7 @@ import java.util.zip.ZipFile
 class LocalSource(private val context: Context) : CatalogueSource {
     companion object {
         const val ID = 0L
-        const val HELP_URL = "https://tachiyomi.org/help/guides/reading-local-manga/"
+        const val HELP_URL = "https://tachiyomi.org/help/guides/local-manga/"
 
         private const val COVER_NAME = "cover.jpg"
         private val SUPPORTED_ARCHIVE_TYPES = setOf("zip", "rar", "cbr", "cbz", "epub")


### PR DESCRIPTION
Updates to the new URL. Maybe create a Cloudflare redirect specifically for this one as well at least for a little while?

Alternatively I can create a page under that url on the website with a link to the updated url since Vuepress own Redirection tools doesn't seem to work as we want them to.