### PR TITLE
Use fetch date instead of upload date when querying recent chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -39,9 +39,9 @@ fun getRecentsQuery() =
     SELECT ${Manga.TABLE}.${Manga.COL_URL} as mangaUrl, * FROM ${Manga.TABLE} JOIN ${Chapter.TABLE}
     ON ${Manga.TABLE}.${Manga.COL_ID} = ${Chapter.TABLE}.${Chapter.COL_MANGA_ID}
     WHERE ${Manga.COL_FAVORITE} = 1 
-    AND ${Chapter.COL_DATE_UPLOAD} > ?
+    AND ${Chapter.COL_DATE_FETCH} > ?
     AND ${Chapter.COL_DATE_FETCH} > ${Manga.COL_DATE_ADDED}
-    ORDER BY ${Chapter.COL_DATE_UPLOAD} DESC
+    ORDER BY ${Chapter.COL_DATE_FETCH} DESC
 """
 
 /**


### PR DESCRIPTION
This will prevent filtering out chapters that don't have upload date from Updates screen.

I only tested it on one manga. Not sure if it can cause some bugs that I can't think of right now.

As for sorting in the query - maybe remove it, since it's kinda redundant? Chapters are sorted on Updates screen anyway.

<details>
<summary>Example</summary>

| Updates screen | Chapter list without dates |
| --- | --- |
| ![Screenshot_1615673386](https://user-images.githubusercontent.com/65343233/111051289-a8de5c00-845a-11eb-84db-ec16c7bb3de4.png) | ![Screenshot_1615673380](https://user-images.githubusercontent.com/65343233/111051293-af6cd380-845a-11eb-949a-ecab943ab0a1.png) |

</details>

<details>
<summary>Explanation</summary>

Original explanation - https://github.com/tachiyomiorg/tachiyomi/issues/4576#issuecomment-798789208

The following query is used in the Updates screen:
https://github.com/tachiyomiorg/tachiyomi/blob/931efed7844d95747cac5a77f07093c710e320c0/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt#L37-L45
2 things to notice here:
- It filters out chapters if their upload date is more than 3 months old (see below). This will filter out chapters that, I guess, set to 0 when upload date isn't set by an extension
https://github.com/tachiyomiorg/tachiyomi/blob/7a373fb43a2d3f736c032d88b31a4a3bffd8dc5b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesPresenter.kt#L72-L77
- It sorts by date upload

But, on Updates screen it sorts and groups them by fetch date
https://github.com/tachiyomiorg/tachiyomi/blob/7a373fb43a2d3f736c032d88b31a4a3bffd8dc5b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesPresenter.kt#L79-L89

So, changing filter to use fetch date won't filter out chapters without upload date. I also changed sort, since in the end it sorts by fetch date anyway.

</details>