### PR TITLE
Remove redundant sort from recent chapters query

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -41,7 +41,6 @@ fun getRecentsQuery() =
     WHERE ${Manga.COL_FAVORITE} = 1 
     AND ${Chapter.COL_DATE_FETCH} > ?
     AND ${Chapter.COL_DATE_FETCH} > ${Manga.COL_DATE_ADDED}
-    ORDER BY ${Chapter.COL_DATE_FETCH} DESC
 """
 
 /**


### PR DESCRIPTION
After recent changes in the query (#4645) some users complain about slow loading of Updates screen (#4673 and few users on Discord). As I explained in #4645, the sort in the query is redundant (it's sorted again later), so we can safely remove it, and this could help to resolve the slow loading problem.

Tested with ~2000 new chapters in emulator, and it actually seems to be faster.