### PR TITLE
Limit query for recent chapters to 500

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -42,6 +42,7 @@ fun getRecentsQuery() =
     AND ${Chapter.COL_DATE_FETCH} > ?
     AND ${Chapter.COL_DATE_FETCH} > ${Manga.COL_DATE_ADDED}
     ORDER BY ${Chapter.COL_DATE_FETCH} DESC
+    LIMIT 500
 """
 
 /**


### PR DESCRIPTION
Alternative for #4677, as discussed on Discord. This time I kept sorting, since we need to find most recent chapters.

Tested with ~2000 chapters, it did load only part of them, and it does seem to be faster.

Closes #4673.