### PR TITLE
Fix renaming download folder

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -135,7 +135,7 @@ class DownloadProvider(private val context: Context) {
     fun getChapterDirName(chapter: Chapter): String {
         return DiskUtil.buildValidFilename(
             when {
-                chapter.scanlator != null -> "${chapter.scanlator}_${chapter.name}"
+                !chapter.scanlator.isNullOrBlank() -> "${chapter.scanlator}_${chapter.name}"
                 else -> chapter.name
             }
         )


### PR DESCRIPTION
This commit will remove the "_" from the beginning of chapter folders if the extension does not have chapter.scanlator