### PR TITLE
Remove weird cropping from icon when showing missing chapter warning

### DIFF
--- a/app/src/main/res/layout/reader_transition_view.xml
+++ b/app/src/main/res/layout/reader_transition_view.xml
@@ -23,10 +23,10 @@
         android:gravity="center_vertical">
 
         <ImageView
-            android:layout_width="16dp"
-            android:layout_height="16dp"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
             android:layout_marginEnd="8dp"
-            android:scaleType="center"
+            android:scaleType="fitCenter"
             app:srcCompat="@drawable/ic_warning_white_24dp"
             app:tint="?attr/colorOnBackground"
             tools:ignore="ContentDescription" />


### PR DESCRIPTION
| Current | Fit Center (16dp) | Fit Center (18dp) |
|---|---|---|
| ![center](https://user-images.githubusercontent.com/6576096/113478718-f282fb00-948a-11eb-94a9-903af5b15aad.png) | ![fitcenter16dp](https://user-images.githubusercontent.com/6576096/113478724-f878dc00-948a-11eb-8b8f-041ca986c827.png) | ![fitcenter18dp](https://user-images.githubusercontent.com/6576096/113478747-1e05e580-948b-11eb-8ce4-475a7446b6dd.png) |
| Currently the warning icon has a weird cropping | Fixed the cropping by using `fitCenter` but with a width and height of `16dp` it felt small | So I also changed the width and height of the `ImageView` to `18dp` |