### PR TITLE
add page split webtoon page (alpha)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -31,6 +31,8 @@ object PreferenceKeys {
 
     const val dualPageInvertWebtoon = "pref_dual_page_invert_webtoon"
 
+    const val pageSplitWebtoon = "pref_page_split_webtoon"
+
     const val showReadingMode = "pref_show_reading_mode"
 
     const val trueColor = "pref_true_color_key"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -101,6 +101,8 @@ class PreferencesHelper(val context: Context) {
 
     fun dualPageInvertWebtoon() = flowPrefs.getBoolean(Keys.dualPageInvertWebtoon, false)
 
+    fun pageSplitWebtoon() = flowPrefs.getBoolean(Keys.pageSplitWebtoon, false)
+
     fun showReadingMode() = prefs.getBoolean(Keys.showReadingMode, true)
 
     fun trueColor() = flowPrefs.getBoolean(Keys.trueColor, false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
@@ -89,7 +89,7 @@ class ReaderReadingModeSettings @JvmOverloads constructor(context: Context, attr
         binding.webtoonPrefsGroup.tappingPrefsGroup.isVisible = preferences.readWithTapping().get()
 
         binding.webtoonPrefsGroup.tappingInverted.bindToPreference(preferences.webtoonNavInverted())
-
+        binding.webtoonPrefsGroup.pageSplitWebtoon.bindToPreference(preferences.pageSplitWebtoon())
         binding.webtoonPrefsGroup.webtoonNav.bindToPreference(preferences.navigationModeWebtoon())
         binding.webtoonPrefsGroup.cropBordersWebtoon.bindToPreference(preferences.cropBordersWebtoon())
         binding.webtoonPrefsGroup.webtoonSidePadding.bindToIntPreference(preferences.webtoonSidePadding(), R.array.webtoon_side_padding_values)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
@@ -33,6 +33,7 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
 
     var navigationOverlayOnStart = false
 
+    var pageSplitWebtoon = false
     var dualPageSplit = false
         protected set
 
@@ -66,6 +67,8 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
 
         preferences.alwaysShowChapterTransition()
             .register({ alwaysShowChapterTransition = it })
+        preferences.pageSplitWebtoon()
+                .register({ pageSplitWebtoon = it }, { imagePropertyChangedListener?.invoke() })
 
         forceNavigationOverlay = preferences.showNavigationOverlayNewUser().get()
         if (forceNavigationOverlay) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
@@ -33,7 +33,6 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
 
     var navigationOverlayOnStart = false
 
-    var pageSplitWebtoon = false
     var dualPageSplit = false
         protected set
 
@@ -67,8 +66,6 @@ abstract class ViewerConfig(preferences: PreferencesHelper, private val scope: C
 
         preferences.alwaysShowChapterTransition()
             .register({ alwaysShowChapterTransition = it })
-        preferences.pageSplitWebtoon()
-                .register({ pageSplitWebtoon = it }, { imagePropertyChangedListener?.invoke() })
 
         forceNavigationOverlay = preferences.showNavigationOverlayNewUser().get()
         if (forceNavigationOverlay) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -6,6 +6,7 @@ import android.widget.LinearLayout
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
+import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
@@ -19,10 +20,31 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
     /**
      * List of currently set items.
      */
-    var items: List<Any> = emptyList()
+    var items: MutableList<Any> = mutableListOf()
         private set
 
     var currentChapter: ReaderChapter? = null
+    fun onPageSplitWebtoon(current: Any?, newPage: InsertPage, clazz: Class<out WebtoonViewer>) {
+        if (current !is ReaderPage) return
+
+        val currentIndex = items.indexOf(current)
+
+        val placeAtIndex = currentIndex + 1
+
+        // It will enter a endless cycle of insert pages
+        if (clazz.isAssignableFrom(WebtoonViewer::class.java) && items[placeAtIndex - 1] is InsertPage) {
+            return
+        }
+
+        // Same here it will enter a endless cycle of insert pages
+        if (items[placeAtIndex] is InsertPage) {
+            return
+        }
+
+        items.add(placeAtIndex, newPage)
+
+        notifyDataSetChanged()
+    }
 
     /**
      * Updates this adapter with the given [chapters]. It handles setting a few pages of the

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -24,21 +24,15 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
         private set
 
     var currentChapter: ReaderChapter? = null
-    fun onPageSplitWebtoon(current: Any?, newPage: InsertPage, clazz: Class<out WebtoonViewer>) {
-        if (current !is ReaderPage) return
+    fun onPageSplitWebtoon(current: ReaderPage?, newPage: InsertPage) {
+        if (current is InsertPage) return
 
         val currentIndex = items.indexOf(current)
 
         val placeAtIndex = currentIndex + 1
 
-        // It will enter a endless cycle of insert pages
-        if (clazz.isAssignableFrom(WebtoonViewer::class.java) && items[placeAtIndex - 1] is InsertPage) {
-            return
-        }
-
-        // Same here it will enter a endless cycle of insert pages
         if (items[placeAtIndex] is InsertPage) {
-            return
+            return // We return here to not insert more of the already split page
         }
 
         items.add(placeAtIndex, newPage)
@@ -209,6 +203,7 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
     fun cleanupPageSplit() {
         val insertPages = items.filterIsInstance(InsertPage::class.java)
+        if (insertPages.size == 0) return
         items.removeAll(insertPages)
         notifyDataSetChanged()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -24,6 +24,7 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
         private set
 
     var currentChapter: ReaderChapter? = null
+
     fun onPageSplitWebtoon(current: ReaderPage?, newPage: InsertPage) {
         if (current is InsertPage) return
 
@@ -37,6 +38,13 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
         items.add(placeAtIndex, newPage)
 
+        notifyDataSetChanged()
+    }
+
+    fun cleanupPageSplit() {
+        val insertPages = items.filterIsInstance(InsertPage::class.java)
+        if (insertPages.size == 0) return
+        items.removeAll(insertPages)
         notifyDataSetChanged()
     }
 
@@ -199,12 +207,5 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
          * View holder type of a chapter transition view.
          */
         const val TRANSITION_VIEW = 1
-    }
-
-    fun cleanupPageSplit() {
-        val insertPages = items.filterIsInstance(InsertPage::class.java)
-        if (insertPages.size == 0) return
-        items.removeAll(insertPages)
-        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -206,4 +206,10 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
          */
         const val TRANSITION_VIEW = 1
     }
+
+    fun cleanupPageSplit() {
+        val insertPages = items.filterIsInstance(InsertPage::class.java)
+        items.removeAll(insertPages)
+        notifyDataSetChanged()
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -25,6 +25,7 @@ class WebtoonConfig(
     var pageSplitWebtoonChangedListener: ((Boolean) -> Unit)? = null
 
     var pageSplitWebtoon = false
+        private set
 
     var imageCropBorders = false
         private set

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -22,6 +22,10 @@ class WebtoonConfig(
     preferences: PreferencesHelper = Injekt.get()
 ) : ViewerConfig(preferences, scope) {
 
+    var pageSplitWebtoonChangedListener: ((Boolean) -> Unit)? = null
+
+    var pageSplitWebtoon = false
+
     var imageCropBorders = false
         private set
 
@@ -50,6 +54,15 @@ class WebtoonConfig(
 
         preferences.dualPageInvertWebtoon()
             .register({ dualPageInvert = it }, { imagePropertyChangedListener?.invoke() })
+
+        preferences.pageSplitWebtoon()
+            .register(
+                { pageSplitWebtoon = it },
+                {
+                    imagePropertyChangedListener?.invoke()
+                    pageSplitWebtoonChangedListener?.invoke(it)
+                }
+            )
     }
 
     override var navigator: ViewerNavigation = defaultNavigation()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -331,11 +331,11 @@ class WebtoonPageHolder(
             else -> ImageUtil.isWebtoonPage(inputStream)
         }
         inputStream = stream
-        
+
         if (!isWebtoonPage) {
             return inputStream
         }
-        
+
         val upperSide = when {
             page !is InsertPage -> ImageUtil.Side.LEFT
             page is InsertPage -> ImageUtil.Side.RIGHT

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -336,9 +336,9 @@ class WebtoonPageHolder(
             return inputStream
         }
 
-        val upperSide = when {
-            page !is InsertPage -> ImageUtil.Side.LEFT
-            page is InsertPage -> ImageUtil.Side.RIGHT
+        val upperSide = when (page) {
+            is InsertPage -> ImageUtil.Side.RIGHT
+            !is InsertPage -> ImageUtil.Side.LEFT
             else -> error("We should choose a side!")
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -331,25 +331,29 @@ class WebtoonPageHolder(
             else -> ImageUtil.isWebtoonPage(inputStream)
         }
         inputStream = stream
-        if (isWebtoonPage) {
-            val upperSide = when {
-                page !is InsertPage -> ImageUtil.Side.LEFT
-                page is InsertPage -> ImageUtil.Side.RIGHT
-                else -> error("We should choose a side!")
-            }
-
-            if (page !is InsertPage) {
-                onPageSplitWebtoon()
-            }
-
-            inputStream = ImageUtil.splitWebtoon(inputStream, upperSide)
+        
+        if (!isWebtoonPage) {
+            return inputStream
         }
+        
+        val upperSide = when {
+            page !is InsertPage -> ImageUtil.Side.LEFT
+            page is InsertPage -> ImageUtil.Side.RIGHT
+            else -> error("We should choose a side!")
+        }
+
+        if (page !is InsertPage) {
+            onPageSplitWebtoon()
+        }
+
+        inputStream = ImageUtil.splitWebtoon(inputStream, upperSide)
         return inputStream
     }
 
     private fun onPageSplitWebtoon() {
-        val newPage = page?.let { InsertPage(it) }
-        page?.let { newPage?.let { it1 -> viewer.onPageSplitWebtoon(it, it1) } }
+        if (page == null) return
+        val newPage = InsertPage(page!!)
+        viewer.onPageSplitWebtoon(page!!, newPage)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.WebtoonLayoutManager
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
+import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
 import eu.kanade.tachiyomi.ui.reader.viewer.BaseViewer
@@ -217,6 +218,10 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
             // No more chapters, show menu because the user is probably going to close the reader
             activity.showMenu()
         }
+    }
+
+    fun onPageSplitWebtoon(currentPage: ReaderPage, newPage: InsertPage) {
+        adapter.onPageSplitWebtoon(currentPage, newPage, this::class.java)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -340,5 +340,4 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
     private fun cleanupPageSplit() {
         adapter.cleanupPageSplit()
     }
-
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -226,10 +226,6 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
         }
     }
 
-    fun onPageSplitWebtoon(currentPage: ReaderPage, newPage: InsertPage) {
-        adapter.onPageSplitWebtoon(currentPage, newPage, this::class.java)
-    }
-
     /**
      * Tells this viewer to set the given [chapters] as active.
      */
@@ -337,7 +333,12 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
         )
     }
 
+    fun onPageSplitWebtoon(currentPage: ReaderPage, newPage: InsertPage) {
+        adapter.onPageSplitWebtoon(currentPage, newPage, this::class.java)
+    }
+
     private fun cleanupPageSplit() {
         adapter.cleanupPageSplit()
     }
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -334,7 +334,7 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
     }
 
     fun onPageSplitWebtoon(currentPage: ReaderPage, newPage: InsertPage) {
-        adapter.onPageSplitWebtoon(currentPage, newPage, this::class.java)
+        adapter.onPageSplitWebtoon(currentPage, newPage)
     }
 
     private fun cleanupPageSplit() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -133,6 +133,12 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
             false
         }
 
+        config.pageSplitWebtoonChangedListener = { enabled ->
+            if (!enabled) {
+                cleanupPageSplit()
+            }
+        }
+
         config.imagePropertyChangedListener = {
             refreshAdapter()
         }
@@ -329,5 +335,9 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
             max(0, position - 3),
             min(position + 3, adapter.itemCount - 1)
         )
+    }
+
+    private fun cleanupPageSplit() {
+        adapter.cleanupPageSplit()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -289,7 +289,6 @@ class SettingsReaderController : SettingsController() {
             switchPreference {
                 key = Keys.pageSplitWebtoon
                 titleRes = R.string.pref_page_split_webtoon
-                summaryRes = R.string.pref_page_split_webtoon_summary
                 defaultValue = false
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -56,6 +56,12 @@ class SettingsReaderController : SettingsController() {
             summaryRes = R.string.pref_show_navigation_mode_summary
             defaultValue = false
         }
+        switchPreference {
+            key = Keys.pageSplitWebtoon
+            titleRes = R.string.pref_page_split_webtoon
+            summaryRes = R.string.pref_page_split_webtoon_summary
+            defaultValue = false
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             switchPreference {
                 key = Keys.trueColor

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -56,12 +56,6 @@ class SettingsReaderController : SettingsController() {
             summaryRes = R.string.pref_show_navigation_mode_summary
             defaultValue = false
         }
-        switchPreference {
-            key = Keys.pageSplitWebtoon
-            titleRes = R.string.pref_page_split_webtoon
-            summaryRes = R.string.pref_page_split_webtoon_summary
-            defaultValue = false
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             switchPreference {
                 key = Keys.trueColor
@@ -291,6 +285,12 @@ class SettingsReaderController : SettingsController() {
                 summaryRes = R.string.pref_dual_page_invert_summary
                 defaultValue = false
                 preferences.dualPageSplitWebtoon().asImmediateFlow { isVisible = it }.launchIn(viewScope)
+            }
+            switchPreference {
+                key = Keys.pageSplitWebtoon
+                titleRes = R.string.pref_page_split_webtoon
+                summaryRes = R.string.pref_page_split_webtoon_summary
+                defaultValue = false
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -89,6 +89,18 @@ object ImageUtil {
     }
 
     /**
+     * Check whether the image is a webtoon image (width * 3 < height), return the result and original stream
+     */
+    fun isWebtoonPage(imageStream: InputStream): Pair<Boolean, InputStream> {
+        val imageBytes = imageStream.readBytes()
+
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size, options)
+
+        return Pair(options.outWidth * 3 < options.outHeight, ByteArrayInputStream(imageBytes))
+    }
+
+    /**
      * Extract the 'side' part from imageStream and return it as InputStream.
      */
     fun splitInHalf(imageStream: InputStream, side: Side): InputStream {
@@ -142,6 +154,32 @@ object ImageUtil {
 
         val output = ByteArrayOutputStream()
         result.compress(Bitmap.CompressFormat.JPEG, 100, output)
+        return ByteArrayInputStream(output.toByteArray())
+    }
+
+    /**
+     * Split the image into top and bottom part from imageStream and return it as InputStream.
+     */
+    fun splitWebtoon(imageStream: InputStream, upperSide: Side): InputStream {
+        val imageBytes = imageStream.readBytes()
+
+        val imageBitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+        val height = imageBitmap.height
+        val width = imageBitmap.width
+
+        val singlePage = Rect(0, 0, width, height / 2)
+
+        val half = Bitmap.createBitmap(width, height / 2, Bitmap.Config.ARGB_8888)
+        val part = when (upperSide) {
+            Side.LEFT -> Rect(0, 0, width, height - height / 2)
+            Side.RIGHT -> Rect(0, height / 2, width, height)
+        }
+        val canvas = Canvas(half)
+        canvas.drawBitmap(imageBitmap, part, singlePage, null)
+
+        val output = ByteArrayOutputStream()
+        half.compress(Bitmap.CompressFormat.JPEG, 100, output)
+
         return ByteArrayInputStream(output.toByteArray())
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -169,7 +169,7 @@ object ImageUtil {
 
         val singlePage = Rect(0, 0, width, height / 2)
 
-        val half = Bitmap.createBitmap(width, height / 2, Bitmap.Config.ARGB_8888)
+        val half = createBitmap(width, height / 2)
         val part = when (upperSide) {
             Side.LEFT -> Rect(0, 0, width, height - height / 2)
             Side.RIGHT -> Rect(0, height / 2, width, height)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -89,7 +89,7 @@ object ImageUtil {
     }
 
     /**
-     * Check whether the image is a webtoon image (width * 3 < height), return the result and original stream
+     * Check whether the image is a webtoon image (Height > 10.000px), return the result and original stream
      */
     fun isWebtoonPage(imageStream: InputStream): Pair<Boolean, InputStream> {
         val imageBytes = imageStream.readBytes()
@@ -97,7 +97,7 @@ object ImageUtil {
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size, options)
 
-        return Pair(options.outWidth * 3 < options.outHeight, ByteArrayInputStream(imageBytes))
+        return Pair(options.outHeight > 10000, ByteArrayInputStream(imageBytes))
     }
 
     /**

--- a/app/src/main/res/layout/reader_webtoon_settings.xml
+++ b/app/src/main/res/layout/reader_webtoon_settings.xml
@@ -65,6 +65,15 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/page_split_webtoon"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:text="@string/pref_page_split_webtoon" />
+
     <androidx.constraintlayout.widget.Group
         android:id="@+id/tapping_prefs_group"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,8 @@
     <string name="pref_dual_page_split">Dual page split</string>
     <string name="pref_dual_page_invert">Invert dual page split placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the dual page split doesn\'t match reading direction</string>
+    <string name="pref_page_split_webtoon">Page Split Webtoon (ALPHA)</string>
+    <string name="pref_page_split_webtoon_summary">Split long webtoon image</string>
     <string name="pref_cutout_short">Show content in cutout area</string>
     <string name="pref_lock_orientation">Lock orientation</string>
     <string name="pref_page_transitions">Animate page transitions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,7 +259,7 @@
     <string name="pref_dual_page_split">Dual page split</string>
     <string name="pref_dual_page_invert">Invert dual page split placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the dual page split doesn\'t match reading direction</string>
-    <string name="pref_page_split_webtoon">Split tall images</string>
+    <string name="pref_page_split_webtoon">Split tall images (Alpha)</string>
     <string name="pref_cutout_short">Show content in cutout area</string>
     <string name="pref_lock_orientation">Lock orientation</string>
     <string name="pref_page_transitions">Animate page transitions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,8 +259,7 @@
     <string name="pref_dual_page_split">Dual page split</string>
     <string name="pref_dual_page_invert">Invert dual page split placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the dual page split doesn\'t match reading direction</string>
-    <string name="pref_page_split_webtoon">Page Split Webtoon (ALPHA)</string>
-    <string name="pref_page_split_webtoon_summary">Split long webtoon image</string>
+    <string name="pref_page_split_webtoon">Split tall images</string>
     <string name="pref_cutout_short">Show content in cutout area</string>
     <string name="pref_lock_orientation">Lock orientation</string>
     <string name="pref_page_transitions">Animate page transitions</string>


### PR DESCRIPTION
split very long webtoon page, to make it less lag/smoother when scrolling

*based on dual page split
*need to split more than 2 if the image is very long or make it dynamic or at least just split into 3