### PR TITLE
Draw edge-to-edge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,7 @@ android {
         exclude("META-INF/LICENSE")
         exclude("META-INF/LICENSE.txt")
         exclude("META-INF/NOTICE")
+        exclude("META-INF/*.kotlin_module")
     }
 
     dependenciesInfo {
@@ -221,6 +222,7 @@ dependencies {
     implementation("com.nightlynexus.viewstatepageradapter:viewstatepageradapter:1.1.0")
     implementation("com.github.chrisbanes:PhotoView:2.3.0")
     implementation("com.github.tachiyomiorg:DirectionalViewPager:1.0.0")
+    implementation("dev.chrisbanes.insetter:insetter:0.5.0")
 
     // 3.2.0+ introduces weird UI blinking or cut off issues on some devices
     val materialDialogsVersion = "3.1.1"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
@@ -13,7 +13,7 @@ abstract class BaseThemedActivity : AppCompatActivity() {
 
     val preferences: PreferencesHelper by injectLazy()
 
-    private val isDarkMode: Boolean by lazy {
+    val isDarkMode: Boolean by lazy {
         val themeMode = preferences.themeMode().get()
         (themeMode == Values.ThemeMode.dark) ||
             (

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionController.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.kanade.tachiyomi.R
@@ -58,6 +59,11 @@ open class ExtensionController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = ExtensionControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsController.kt
@@ -22,6 +22,7 @@ import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
+import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.preference.EmptyPreferenceDataStore
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -67,6 +68,11 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         val themedInflater = inflater.cloneInContext(getPreferenceThemeContext())
         binding = ExtensionDetailControllerBinding.inflate(themedInflater)
+        binding.extensionPrefsRecycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesController.kt
@@ -7,6 +7,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.databinding.MigrationSourcesControllerBinding
@@ -31,6 +32,11 @@ class MigrationSourcesController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = MigrationSourcesControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
@@ -14,6 +14,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItems
 import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.kanade.tachiyomi.R
@@ -72,6 +73,11 @@ class SourceController :
      */
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = SourceMainControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
@@ -18,6 +18,7 @@ import com.afollestad.materialdialogs.list.listItems
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.tfcporciuncula.flow.Preference
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.kanade.tachiyomi.R
@@ -237,6 +238,11 @@ open class BrowseSourceController(bundle: Bundle) :
         if (filterSheet != null) {
             // Add bottom padding if filter FAB is visible
             recycler.updatePadding(bottom = view.resources.getDimensionPixelOffset(R.dimen.fab_list_padding))
+            recycler.applyInsetter {
+                type(navigationBars = true) {
+                    padding()
+                }
+            }
             recycler.clipToPadding = false
 
             actionFab?.shrinkOnScroll(recycler)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchController.kt
@@ -5,6 +5,7 @@ import android.view.*
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
+import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -53,6 +54,11 @@ open class GlobalSearchController(
      */
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = GlobalSearchControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryController.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.snackbar.Snackbar
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.davidea.flexibleadapter.helpers.UndoHelper
@@ -75,6 +76,11 @@ class CategoryController :
      */
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = CategoriesControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadController.kt
@@ -10,6 +10,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.download.model.Download
@@ -56,6 +57,11 @@ class DownloadController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = DownloadControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.kanade.tachiyomi.R
@@ -79,6 +80,12 @@ class LibraryCategoryView @JvmOverloads constructor(context: Context, attrs: Att
         } else {
             (binding.swipeRefresh.inflate(R.layout.library_grid_recycler) as AutofitRecyclerView).apply {
                 spanCount = controller.mangaPerRow
+            }
+        }
+
+        recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -2,11 +2,16 @@ package eu.kanade.tachiyomi.ui.main
 
 import android.app.SearchManager
 import android.content.Intent
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
@@ -18,6 +23,7 @@ import com.bluelinelabs.conductor.Router
 import com.bluelinelabs.conductor.RouterTransaction
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
+import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.Migrations
 import eu.kanade.tachiyomi.R
@@ -84,6 +90,35 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
 
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
+
+        // Draw edge-to-edge
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        binding.appbar.applyInsetter {
+            type(navigationBars = true, statusBars = true) {
+                padding(left = true, top = true, right = true)
+            }
+        }
+        binding.bottomNav.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
+        binding.rootFab.applyInsetter {
+            type(navigationBars = true) {
+                margin()
+            }
+        }
+
+        // Make sure navigation bar is on bottom when making it transparent
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            if (insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom > 0) {
+                // Keep scrim on light theme if windowLightNavigationBar is not available
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 || isDarkMode) {
+                    window.navigationBarColor = Color.TRANSPARENT
+                }
+            }
+            insets
+        }
 
         tabAnimator = ViewHeightAnimator(binding.tabs, 0L)
         bottomNavAnimator = ViewHeightAnimator(binding.bottomNav)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -26,6 +26,7 @@ import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.snackbar.Snackbar
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.kanade.tachiyomi.R
@@ -200,6 +201,11 @@ class MangaController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = MangaControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.afollestad.materialdialogs.MaterialDialog
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.backup.BackupRestoreService
@@ -77,6 +78,11 @@ class HistoryController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = HistoryControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesController.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.recyclerview.widget.LinearLayoutManager
+import dev.chrisbanes.insetter.applyInsetter
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -76,6 +77,11 @@ class UpdatesController :
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
         binding = UpdatesControllerBinding.inflate(inflater)
+        binding.recycler.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsController.kt
@@ -17,6 +17,7 @@ import androidx.preference.PreferenceGroup
 import androidx.preference.PreferenceScreen
 import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
+import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.base.controller.BaseController
@@ -47,6 +48,12 @@ abstract class SettingsController : PreferenceController() {
 
         if (this is RootController) {
             view.updatePadding(bottom = view.context.resources.getDimensionPixelSize(R.dimen.action_toolbar_list_padding))
+        }
+
+        listView.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
         }
 
         return view

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <style name="Theme.Tachiyomi.Light.Api23">
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/md_white_1000</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <!-- Application Colors -->
     <color name="colorPrimary">#54759E</color>
     <color name="colorPrimaryDark">#435E7E</color>
+    <color name="colorPrimary_70">#B354759E</color>
 
     <!-- Dark Application Colors -->
     <color name="colorDarkPrimary">#242529</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -88,7 +88,7 @@
     <!-- Main Theme-->
     <!--===========-->
     <style name="Theme.Tachiyomi.Light" parent="Theme.Base">
-        <item name="android:statusBarColor">@color/md_black_1000_54</item>
+        <item name="android:statusBarColor">@color/md_black_1000</item>
         <item name="android:navigationBarColor">@color/md_black_1000_54</item>
 
         <item name="colorFilterActive">@color/filterColorLight</item>
@@ -101,6 +101,8 @@
         <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
 
         <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
+
+        <item name="android:navigationBarColor">@color/colorPrimary_70</item>
     </style>
 
     <!--=============-->


### PR DESCRIPTION
Insets are handled by [Insetter](https://chrisbanes.github.io/insetter/) so it should be consistent across APIs.

The navigation bar color will only be set transparent when it's positioned on the bottom (e.g., on landscape orientation with non-gesture navbar won't be set transparent).

[portrait](https://user-images.githubusercontent.com/12537387/114224914-e7a0fc80-999b-11eb-9987-8d6b36f24885.png)
[landscape gesture 1](https://user-images.githubusercontent.com/12537387/114224630-8547fc00-999b-11eb-88d6-e9114bf64efd.png)
[landscape gesture 2](https://user-images.githubusercontent.com/12537387/114224754-b0325000-999b-11eb-88f5-73b73ac36fc5.png)
[landscape 3-button 1](https://user-images.githubusercontent.com/12537387/114224820-c5a77a00-999b-11eb-841e-3ab1617a5a24.png)
[landscape 3-button 2](https://user-images.githubusercontent.com/12537387/114225267-54b49200-999c-11eb-82e5-6ce296cdf5bb.png)