### PR TITLE
Add navigation bar scrim

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
@@ -13,7 +13,7 @@ abstract class BaseThemedActivity : AppCompatActivity() {
 
     val preferences: PreferencesHelper by injectLazy()
 
-    val isDarkMode: Boolean by lazy {
+    private val isDarkMode: Boolean by lazy {
         val themeMode = preferences.themeMode().get()
         (themeMode == Values.ThemeMode.dark) ||
             (

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -24,7 +24,6 @@ import com.bluelinelabs.conductor.Router
 import com.bluelinelabs.conductor.RouterTransaction
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
-import dev.chrisbanes.insetter.Insetter
 import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.Migrations
@@ -103,26 +102,16 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
                 margin(top = true)
             }
         }
-        binding.rootFab.applyInsetter {
-            type(navigationBars = true) {
-                margin()
-            }
-        }
         binding.bottomNav.applyInsetter {
             type(navigationBars = true) {
                 padding()
             }
         }
-        Insetter.builder()
-            .consume(Insetter.CONSUME_ALL)
-            .setOnApplyInsetsListener { view, insets, _ ->
-                val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-                view.isVisible = systemInsets.bottom > 0
-                view.updateLayoutParams<ViewGroup.LayoutParams> {
-                    height = systemInsets.bottom
-                }
+        binding.rootFab.applyInsetter {
+            type(navigationBars = true) {
+                margin()
             }
-            .applyToView(binding.navigationScrim)
+        }
 
         // Make sure navigation bar is on bottom when making it transparent
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -50,6 +50,8 @@ import eu.kanade.tachiyomi.ui.recent.history.HistoryController
 import eu.kanade.tachiyomi.ui.recent.updates.UpdatesController
 import eu.kanade.tachiyomi.util.lang.launchIO
 import eu.kanade.tachiyomi.util.lang.launchUI
+import eu.kanade.tachiyomi.util.system.InternalResourceHelper
+import eu.kanade.tachiyomi.util.system.getResourceColor
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -113,12 +115,16 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
             }
         }
 
-        // Make sure navigation bar is on bottom when making it transparent
+        // Make sure navigation bar is on bottom before we modify it
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
             if (insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom > 0) {
-                // Keep scrim on light theme if windowLightNavigationBar is not available
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 || isDarkMode) {
-                    window.navigationBarColor = Color.TRANSPARENT
+                window.navigationBarColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                    !InternalResourceHelper.getBoolean(this, "config_navBarNeedsScrim", true)
+                ) {
+                    Color.TRANSPARENT
+                } else {
+                    // Set navbar scrim 70% of navigationBarColor
+                    getResourceColor(android.R.attr.navigationBarColor, .7F)
                 }
             }
             insets

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/InternalResourceHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/InternalResourceHelper.kt
@@ -1,0 +1,25 @@
+package eu.kanade.tachiyomi.util.system
+
+import android.content.Context
+import android.content.res.Resources
+
+object InternalResourceHelper {
+    /**
+     * Get resource id from system resources
+     * @param resName resource name to get
+     * @param type resource type of [resName] to get
+     * @return 0 if not available
+     */
+    private fun getResourceId(resName: String, type: String): Int {
+        return Resources.getSystem().getIdentifier(resName, type, "android")
+    }
+
+    fun getBoolean(context: Context, resName: String, defaultValue: Boolean): Boolean {
+        val id = getResourceId(resName, "bool")
+        return if (id != 0) {
+            context.createPackageContext("android", 0).resources.getBoolean(id)
+        } else {
+            defaultValue
+        }
+    }
+}

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -91,17 +91,4 @@
         app:layout_insetEdge="bottom"
         app:menu="@menu/bottom_nav" />
 
-    <View
-        android:id="@+id/navigation_scrim"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_gravity="bottom"
-        android:alpha="0.5"
-        android:background="?android:attr/navigationBarColor"
-        android:clickable="false"
-        android:focusable="false"
-        android:visibility="gone"
-        tools:layout_height="?attr/actionBarSize"
-        tools:visibility="visible" />
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -201,7 +201,7 @@
         <item name="android:colorBackground">@color/colorAmoledPrimary</item>
 
         <!-- Some ROMs make black navbars white (e.g. OxygenOS) -->
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">#000001</item>
 
         <!-- Custom Attributes-->
         <item name="colorLibrarySelection">@color/selectorColorDark</item>


### PR DESCRIPTION
This checks for a internal flag `config_navBarNeedsScrim` added since API 29. It exists in pretty much all of my test devices (Pixel 3, Xperia 5II and Galaxy A50).

If the flag explicitly set to false, navbar color will be set to transparent, else it will use 70% of navigationBarColor.