### PR TITLE
Support parsing volume numbers as chapters for volume-only titles

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterRecognition.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterRecognition.kt
@@ -54,6 +54,19 @@ object ChapterRecognition {
             it.forEach { occurrence -> name = name.replace(occurrence.value, occurrence.value.trim()) }
         }
 
+        // Start by checking for one number occurrence before any name manipulation
+        // to support volume-only files
+        val occurrences: MutableList<MatchResult> = arrayListOf()
+        occurrence.findAll(name).let {
+            it.forEach { occurrence -> occurrences.add(occurrence) }
+        }
+
+        if (occurrences.size == 1) {
+            if (updateChapter(occurrences[0], chapter)) {
+                return
+            }
+        }
+
         // Remove unwanted tags.
         unwanted.findAll(name).let {
             it.forEach { occurrence -> name = name.replace(occurrence.value, "") }
@@ -64,8 +77,8 @@ object ChapterRecognition {
             return
         }
 
-        // Check one number occurrence.
-        val occurrences: MutableList<MatchResult> = arrayListOf()
+        // Check one number occurrence again now unwanted tags are removed
+        occurrences.clear()
         occurrence.findAll(name).let {
             it.forEach { occurrence -> occurrences.add(occurrence) }
         }


### PR DESCRIPTION
For cases where manga is a volume, the previous behaviour would result
in the "volume" tag and number being removed and all files end up as
"chapter -1".

This change adds an additional check for the single occurrence of
numbers before removing the unwanted tags, so files named, eg
`attackontitan_vol1.cbz` or epubs with metadata `Attack on Titan
Vol 1`  can still have the "chapter" number parsed for sorting
in the library, while continuing to support cases where the single
number match would happen after the volume tags are removed