### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: inorichi
 ko_fi: inorichi


### PR DESCRIPTION
closes #4906

inorichi doesn't have GitHub Sponsor which causes an error/warning message when trying to donate

I don't know if GitHub Sponsor is available in the country where @inorichi lives else he could activate it to remove the warning