### PR TITLE
Cleanup dual page split

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -235,7 +235,6 @@ class PagerPageHolder(
         readImageHeaderSubscription = Observable
             .fromCallable {
                 val stream = streamFn().buffered(16)
-
                 openStream = process(stream)
 
                 ImageUtil.findImageType(stream) == ImageUtil.ImageType.GIF
@@ -255,26 +254,26 @@ class PagerPageHolder(
             .subscribe({}, {})
     }
 
-    private fun process(openStream: InputStream): InputStream {
+    private fun process(imageStream: InputStream): InputStream {
         if (!viewer.config.dualPageSplit) {
-            return openStream
+            return imageStream
         }
 
         if (page is InsertPage) {
-            return splitInHalf(openStream)
+            return splitInHalf(imageStream)
         }
 
-        val isDoublePage = ImageUtil.isDoublePage(openStream)
+        val isDoublePage = ImageUtil.isDoublePage(imageStream)
         if (!isDoublePage) {
-            return openStream
+            return imageStream
         }
 
         onPageSplit()
 
-        return splitInHalf(openStream)
+        return splitInHalf(imageStream)
     }
 
-    private fun splitInHalf(inputStream: InputStream): InputStream {
+    private fun splitInHalf(imageStream: InputStream): InputStream {
         var side = when {
             viewer is L2RPagerViewer && page is InsertPage -> ImageUtil.Side.RIGHT
             viewer !is L2RPagerViewer && page is InsertPage -> ImageUtil.Side.LEFT
@@ -290,7 +289,7 @@ class PagerPageHolder(
             }
         }
 
-        return ImageUtil.splitInHalf(inputStream, side)
+        return ImageUtil.splitInHalf(imageStream, side)
     }
 
     private fun onPageSplit() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -385,7 +385,10 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
     }
 
     fun onPageSplit(currentPage: ReaderPage, newPage: InsertPage) {
-        adapter.onPageSplit(currentPage, newPage, this::class.java)
+        activity.runOnUiThread {
+            // Need to insert on UI thread else images will go blank
+            adapter.onPageSplit(currentPage, newPage, this::class.java)
+        }
     }
 
     private fun cleanupPageSplit() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -281,7 +281,6 @@ class WebtoonPageHolder(
         readImageHeaderSubscription = Observable
             .fromCallable {
                 val stream = streamFn().buffered(16)
-
                 openStream = process(stream)
 
                 ImageUtil.findImageType(stream) == ImageUtil.ImageType.GIF
@@ -307,18 +306,18 @@ class WebtoonPageHolder(
         addSubscription(readImageHeaderSubscription)
     }
 
-    private fun process(inputStream: InputStream): InputStream {
+    private fun process(imageStream: InputStream): InputStream {
         if (!viewer.config.dualPageSplit) {
-            return inputStream
+            return imageStream
         }
 
-        val isDoublePage = ImageUtil.isDoublePage(inputStream)
+        val isDoublePage = ImageUtil.isDoublePage(imageStream)
         if (!isDoublePage) {
-            return inputStream
+            return imageStream
         }
 
         val upperSide = if (viewer.config.dualPageInvert) ImageUtil.Side.LEFT else ImageUtil.Side.RIGHT
-        return ImageUtil.splitAndMerge(inputStream, upperSide)
+        return ImageUtil.splitAndMerge(imageStream, upperSide)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -289,12 +289,10 @@ class WebtoonPageHolder(
             .observeOn(AndroidSchedulers.mainThread())
             .doOnNext { isAnimated ->
                 if (viewer.config.dualPageSplit) {
-                    val (isDoublePage, stream) = ImageUtil.isDoublePage(openStream!!)
-                    openStream = if (!isDoublePage) {
-                        stream
-                    } else {
+                    val isDoublePage = ImageUtil.isDoublePage(openStream!!)
+                    if (isDoublePage) {
                         val upperSide = if (viewer.config.dualPageInvert) ImageUtil.Side.LEFT else ImageUtil.Side.RIGHT
-                        ImageUtil.splitAndMerge(stream, upperSide)
+                        openStream = ImageUtil.splitAndMerge(openStream!!, upperSide)
                     }
                 }
                 if (!isAnimated) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -79,13 +79,17 @@ object ImageUtil {
     /**
      * Check whether the image is a double image (width > height), return the result and original stream
      */
-    fun isDoublePage(imageStream: InputStream): Pair<Boolean, InputStream> {
+    fun isDoublePage(imageStream: InputStream): Boolean {
+        imageStream.mark(Int.MAX_VALUE)
+
         val imageBytes = imageStream.readBytes()
 
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size, options)
 
-        return Pair(options.outWidth > options.outHeight, ByteArrayInputStream(imageBytes))
+        imageStream.reset()
+
+        return options.outWidth > options.outHeight
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -80,7 +80,7 @@ object ImageUtil {
      * Check whether the image is a double image (width > height), return the result and original stream
      */
     fun isDoublePage(imageStream: InputStream): Boolean {
-        imageStream.mark(Int.MAX_VALUE)
+        imageStream.mark(imageStream.available() + 1)
 
         val imageBytes = imageStream.readBytes()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -77,7 +77,8 @@ object ImageUtil {
     }
 
     /**
-     * Check whether the image is a double image (width > height), return the result and original stream
+     * Check whether the image is a double-page spread
+     * @return true if the width is greater than the height
      */
     fun isDoublePage(imageStream: InputStream): Boolean {
         imageStream.mark(imageStream.available() + 1)


### PR DESCRIPTION
This is a cleanup of the dual page split logic and also changes so it processes the stream in the same place like J2K.

I have not noticed a performance benefit with this when using dual page split it is basically the same, but I have noticed a performance benefit if we do something like my stencil page idea in #4791 it will be a lot smoother if it processes the stream on IO rather than the main thread

