### PR TITLE
Make the download progress status smoother

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -727,8 +727,7 @@ class MangaController :
 
     fun onChapterDownloadUpdate(download: Download) {
         chaptersAdapter?.currentItems?.find { it.id == download.chapter.id }?.let {
-            chaptersAdapter?.updateItem(it)
-            chaptersAdapter?.notifyDataSetChanged()
+            chaptersAdapter?.updateItem(it, it.status)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterDownloadView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterDownloadView.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.databinding.ChapterDownloadViewBinding
 
@@ -60,8 +62,18 @@ class ChapterDownloadView @JvmOverloads constructor(context: Context, attrs: Att
         binding.downloadProgress.isVisible = state == Download.State.DOWNLOADING
         binding.downloadProgress.setProgressCompat(progress, true)
 
-        binding.downloadedIcon.isVisible = state == Download.State.DOWNLOADED
-
-        binding.errorIcon.isVisible = state == Download.State.ERROR
+        binding.downloadStatusIcon.apply {
+            if (state == Download.State.DOWNLOADED || state == Download.State.ERROR) {
+                isVisible = true
+                val drawable = if (state == Download.State.DOWNLOADED) {
+                    ContextCompat.getDrawable(context, R.drawable.ic_check_circle_24dp)
+                } else {
+                    ContextCompat.getDrawable(context, R.drawable.ic_error_outline_24dp)
+                }
+                setImageDrawable(drawable)
+            } else {
+                isVisible = false
+            }
+        }
     }
 }

--- a/app/src/main/res/drawable/ic_error_outline_24dp.xml
+++ b/app/src/main/res/drawable/ic_error_outline_24dp.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?colorError">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z" />

--- a/app/src/main/res/layout/chapter_download_view.xml
+++ b/app/src/main/res/layout/chapter_download_view.xml
@@ -39,23 +39,12 @@
         app:trackThickness="2dp" />
 
     <ImageView
-        android:id="@+id/downloaded_icon"
+        android:id="@+id/download_status_icon"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="fitXY"
         android:visibility="gone"
-        app:srcCompat="@drawable/ic_check_circle_24dp"
         app:tint="?android:attr/textColorPrimary"
-        tools:ignore="ContentDescription" />
-
-    <ImageView
-        android:id="@+id/error_icon"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="fitXY"
-        android:visibility="gone"
-        app:srcCompat="@drawable/ic_error_outline_24dp"
-        app:tint="?attr/colorError"
         tools:ignore="ContentDescription" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/chapter_download_view.xml
+++ b/app/src/main/res/layout/chapter_download_view.xml
@@ -38,18 +38,6 @@
         app:indicatorSize="24dp"
         app:trackThickness="2dp" />
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:id="@+id/download_queued"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:indeterminate="true"
-        android:padding="1dp"
-        android:visibility="gone"
-        app:indicatorColor="?android:attr/textColorHint"
-        app:indicatorInset="0dp"
-        app:indicatorSize="24dp"
-        app:trackThickness="2dp" />
-
     <ImageView
         android:id="@+id/downloaded_icon"
         android:layout_width="match_parent"


### PR DESCRIPTION
Replaced the indeterminable progress indicator with blinking download icon for queued items as it looks chaotic since it's impossible to sync the indicator animation.

[Before](https://user-images.githubusercontent.com/12537387/115992762-8e6ed500-a5f9-11eb-89f8-c9bd2b7275cc.mp4)
[After](https://user-images.githubusercontent.com/12537387/115992822-cf66e980-a5f9-11eb-9a97-bbf3b11763a5.mp4)

