### PR TITLE
Fix bugs in dual-page split

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
+import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
@@ -366,6 +367,11 @@ class ReaderPresenter(
         val currentChapters = viewerChaptersRelay.value ?: return
 
         val selectedChapter = page.chapter
+
+        // Insert page doesn't change page progress
+        if (page is InsertPage) {
+            return
+        }
 
         // Save last page read and mark as read if needed
         selectedChapter.chapter.last_page_read = page.index

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -230,7 +230,7 @@ class PagerPageHolder(
         readImageHeaderSubscription = Observable
             .fromCallable {
                 val stream = streamFn().buffered(16)
-                openStream = process(stream)
+                openStream = process(item, stream)
 
                 ImageUtil.findImageType(stream) == ImageUtil.ImageType.GIF
             }
@@ -249,7 +249,7 @@ class PagerPageHolder(
             .subscribe({}, {})
     }
 
-    private fun process(imageStream: InputStream): InputStream {
+    private fun process(page: ReaderPage, imageStream: InputStream): InputStream {
         if (!viewer.config.dualPageSplit) {
             return imageStream
         }
@@ -263,7 +263,7 @@ class PagerPageHolder(
             return imageStream
         }
 
-        onPageSplit()
+        onPageSplit(page)
 
         return splitInHalf(imageStream)
     }
@@ -287,7 +287,7 @@ class PagerPageHolder(
         return ImageUtil.splitInHalf(imageStream, side)
     }
 
-    private fun onPageSplit() {
+    private fun onPageSplit(page: ReaderPage) {
         val newPage = InsertPage(page)
         viewer.onPageSplit(page, newPage)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -192,6 +192,11 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         Timber.d("onReaderPageSelected: ${page.number}/${pages.size}")
         activity.onPageSelected(page)
 
+        // Skip preload on inserts it causes unwanted page jumping
+        if (page is InsertPage) {
+            return
+        }
+
         // Preload next chapter once we're within the last 5 pages of the current chapter
         val inPreloadRange = pages.size - page.number < 5
         if (inPreloadRange && allowPreload && page.chapter == adapter.currentChapter) {
@@ -387,7 +392,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
     fun onPageSplit(currentPage: ReaderPage, newPage: InsertPage) {
         activity.runOnUiThread {
             // Need to insert on UI thread else images will go blank
-            adapter.onPageSplit(currentPage, newPage, this::class.java)
+            adapter.onPageSplit(currentPage, newPage)
         }
     }
 


### PR DESCRIPTION
fixes #4982

Have tested with the chapters provided in the issue. Did make a local version of the chapters provided to see if it was caused at other positions as well. Did also test with a chapter only containing dual page spreads. And everything seems to work as intended now.

Webtoon dual-page split doesn't have this issue due to it not inserting another page into the RecyclerView

