### PR TITLE
add refresh tracking action to restore complete notification 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -132,8 +132,6 @@ class BackupNotifier(private val context: Context) {
             )
         )
 
-        val size = trackManager.services.size
-
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.restore_completed))
             setContentText(context.resources.getQuantityString(R.plurals.restore_completed_message, errorCount, timeString, errorCount))
@@ -153,7 +151,7 @@ class BackupNotifier(private val context: Context) {
             }
 
             // add action to refresh tracking if Trackers are set up
-            if (size > 1) {
+            if (trackManager.hasLoggedServices()) {
                 addAction(
                     R.drawable.ic_folder_24dp,
                     context.getString(R.string.pref_refresh_library_tracking),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -146,6 +146,12 @@ class BackupNotifier(private val context: Context) {
                 )
             }
 
+            addAction(
+                R.drawable.ic_folder_24dp,
+                context.getString(R.string.pref_refresh_library_tracking),
+                NotificationReceiver.refreshTrackingPendingBroadcast(context, Notifications.ID_RESTORE_COMPLETE)
+            )
+
             show(Notifications.ID_RESTORE_COMPLETE)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -80,6 +80,10 @@ class NotificationReceiver : BroadcastReceiver() {
                 context,
                 intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
             )
+            ACTION_REFRESH_TRACKING -> refreshTracking(
+                context,
+                intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+            )
             // Cancel library update and dismiss notification
             ACTION_CANCEL_LIBRARY_UPDATE -> cancelLibraryUpdate(context, Notifications.ID_LIBRARY_PROGRESS)
             // Open reader activity
@@ -212,6 +216,20 @@ class NotificationReceiver : BroadcastReceiver() {
     }
 
     /**
+     * Method called when user wants to refresh tracking
+     * uses the same job as used for refresh tracking in advanced settings
+     *
+     * @param context context of application
+     * @param notificationId id of notification
+     */
+    private fun refreshTracking(context: Context, notificationId: Int) {
+        // Dismiss notification
+        dismissNotification(context, notificationId)
+
+        LibraryUpdateService.start(context, target = LibraryUpdateService.Target.TRACKING)
+    }
+
+    /**
      * Method called when user wants to stop a library update
      *
      * @param context context of application
@@ -258,6 +276,7 @@ class NotificationReceiver : BroadcastReceiver() {
         private const val ACTION_DELETE_IMAGE = "$ID.$NAME.DELETE_IMAGE"
 
         private const val ACTION_SHARE_BACKUP = "$ID.$NAME.SEND_BACKUP"
+        private const val ACTION_REFRESH_TRACKING = "$ID.$NAME.REFRESH_TRACKING"
 
         private const val ACTION_SHARE_CRASH_LOG = "$ID.$NAME.SEND_CRASH_LOG"
 
@@ -547,6 +566,21 @@ class NotificationReceiver : BroadcastReceiver() {
         internal fun cancelRestorePendingBroadcast(context: Context, notificationId: Int): PendingIntent {
             val intent = Intent(context, NotificationReceiver::class.java).apply {
                 action = ACTION_CANCEL_RESTORE
+                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+            }
+            return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
+        /**
+         * Returns [PendingIntent] that sets up library update job for refreshing tracking
+         *
+         * @param context context of application
+         * @param notificationId id of notification
+         * @return [PendingIntent]
+         */
+        internal fun refreshTrackingPendingBroadcast(context: Context, notificationId: Int): PendingIntent {
+            val intent = Intent(context, NotificationReceiver::class.java).apply {
+                action = ACTION_REFRESH_TRACKING
                 putExtra(EXTRA_NOTIFICATION_ID, notificationId)
             }
             return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)


### PR DESCRIPTION
also shows the action only when user has logged in to trackers

screenshots attached:

| Successful Restore (No Trackers) | Successful Restore (with Trackers) |
|--|--|
| ![restore-complete-no-tracker](https://user-images.githubusercontent.com/72807749/116746393-0aae5180-aa1a-11eb-8101-73bd69c9a6b9.png) | ![restore-complete-with-tracking](https://user-images.githubusercontent.com/72807749/116746407-10a43280-aa1a-11eb-8b83-b7c851a48f61.png) | 

| Restore with Error (No Trackers) | Restore with Error (with Trackers) |
|--|--|
|![restore-complete-error-no-tracking](https://user-images.githubusercontent.com/72807749/116746507-329db500-aa1a-11eb-8cfe-10ef26659c34.png)  | ![restore-complete-error-with-tracker](https://user-images.githubusercontent.com/72807749/116746503-303b5b00-aa1a-11eb-8c2e-468a9f1580ef.png) | 

EDIT: placed the screenshots correctly