### PR TITLE
Automatic background color for PagerViewer

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -23,6 +23,9 @@ class PagerConfig(
     preferences: PreferencesHelper = Injekt.get()
 ) : ViewerConfig(preferences, scope) {
 
+    var automaticBackground = false
+        private set
+
     var dualPageSplitChangedListener: ((Boolean) -> Unit)? = null
 
     var imageScaleType = 1
@@ -35,6 +38,9 @@ class PagerConfig(
         private set
 
     init {
+        preferences.readerTheme()
+            .register({ automaticBackground = it == 3 }, { imagePropertyChangedListener?.invoke() })
+
         preferences.imageScaleType()
             .register({ imageScaleType = it }, { imagePropertyChangedListener?.invoke() })
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -239,7 +239,9 @@ class PagerPageHolder(
             .doOnNext { isAnimated ->
                 if (!isAnimated) {
                     initSubsamplingImageView().apply {
-                        background = ImageUtil.chooseBackground(context, openStream!!)
+                        if (viewer.config.automaticBackground) {
+                            background = ImageUtil.chooseBackground(context, openStream!!)
+                        }
                         setImage(ImageSource.inputStream(openStream!!))
                     }
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -238,7 +238,10 @@ class PagerPageHolder(
             .observeOn(AndroidSchedulers.mainThread())
             .doOnNext { isAnimated ->
                 if (!isAnimated) {
-                    initSubsamplingImageView().setImage(ImageSource.inputStream(openStream!!))
+                    initSubsamplingImageView().apply {
+                        background = ImageUtil.chooseBackground(context, openStream!!)
+                        setImage(ImageSource.inputStream(openStream!!))
+                    }
                 } else {
                     initImageView().setImage(openStream!!)
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -172,10 +172,10 @@ object ImageUtil {
 
         imageStream.reset()
 
-        val backgroundColor = Color.WHITE
-        if (image == null) return ColorDrawable(backgroundColor)
+        val whiteColor = Color.WHITE
+        if (image == null) return ColorDrawable(whiteColor)
         if (image.width < 50 || image.height < 50) {
-            return ColorDrawable(backgroundColor)
+            return ColorDrawable(whiteColor)
         }
 
         val top = 5
@@ -227,12 +227,12 @@ object ImageUtil {
             darkBG = false
         }
 
-        var blackPixel = when {
+        var blackColor = when {
             topLeftIsDark -> topLeftPixel
             topRightIsDark -> topRightPixel
             botLeftIsDark -> botLeftPixel
             botRightIsDark -> botRightPixel
-            else -> backgroundColor
+            else -> whiteColor
         }
 
         var overallWhitePixels = 0
@@ -291,10 +291,10 @@ object ImageUtil {
             when {
                 blackPixels > 22 -> {
                     if (x == right || x == right + offsetX) {
-                        blackPixel = when {
+                        blackColor = when {
                             topRightIsDark -> topRightPixel
                             botRightIsDark -> botRightPixel
-                            else -> blackPixel
+                            else -> blackColor
                         }
                     }
                     darkBG = true
@@ -304,10 +304,10 @@ object ImageUtil {
                 blackStreak -> {
                     darkBG = true
                     if (x == right || x == right + offsetX) {
-                        blackPixel = when {
+                        blackColor = when {
                             topRightIsDark -> topRightPixel
                             botRightIsDark -> botRightPixel
-                            else -> blackPixel
+                            else -> blackColor
                         }
                     }
                     if (blackPixels > 18) {
@@ -327,44 +327,48 @@ object ImageUtil {
         if (topIsBlackStreak && bottomIsBlackStreak) {
             darkBG = true
         }
+
         val isLandscape = context.resources.configuration?.orientation == Configuration.ORIENTATION_LANDSCAPE
-        if (darkBG) {
-            return if (!isLandscape && botLeftPixel.isWhite() && botRightPixel.isWhite()) GradientDrawable(
-                    GradientDrawable.Orientation.TOP_BOTTOM,
-                    intArrayOf(blackPixel, blackPixel, backgroundColor, backgroundColor)
-            )
-            else if (!isLandscape && topLeftPixel.isWhite() && topRightPixel.isWhite()) GradientDrawable(
-                    GradientDrawable.Orientation.TOP_BOTTOM,
-                    intArrayOf(backgroundColor, backgroundColor, blackPixel, blackPixel)
-            )
-            else ColorDrawable(blackPixel)
+        if (isLandscape) {
+            return when {
+                darkBG -> ColorDrawable(blackColor)
+                else -> ColorDrawable(whiteColor)
+            }
         }
-        if (!isLandscape && (
-                        topIsBlackStreak || (
-                                topLeftIsDark && topRightIsDark &&
-                                        image.getPixel(left - offsetX, top).isDark() && image.getPixel(right + offsetX, top).isDark() &&
-                                        (topMidIsDark || overallBlackPixels > 9)
-                                )
-                        )
-        ) {
-            return GradientDrawable(
-                    GradientDrawable.Orientation.TOP_BOTTOM,
-                    intArrayOf(blackPixel, blackPixel, backgroundColor, backgroundColor)
-            )
-        } else if (!isLandscape && (
-                        bottomIsBlackStreak || (
-                                botLeftIsDark && botRightIsDark &&
-                                        image.getPixel(left - offsetX, bot).isDark() && image.getPixel(right + offsetX, bot).isDark() &&
-                                        (bottomCenterPixel.isDark() || overallBlackPixels > 9)
-                                )
-                        )
-        ) {
-            return GradientDrawable(
-                    GradientDrawable.Orientation.TOP_BOTTOM,
-                    intArrayOf(backgroundColor, backgroundColor, blackPixel, blackPixel)
-            )
+
+        val gradient = when {
+            darkBG && botLeftPixel.isWhite() && botRightPixel.isWhite() -> {
+                intArrayOf(blackColor, blackColor, whiteColor, whiteColor)
+            }
+            darkBG && topLeftPixel.isWhite() && topRightPixel.isWhite() -> {
+                intArrayOf(whiteColor, whiteColor, blackColor, blackColor)
+            }
+            darkBG -> {
+                return ColorDrawable(blackColor)
+            }
+            topIsBlackStreak || (
+                topLeftIsDark && topRightIsDark &&
+                    image.getPixel(left - offsetX, top).isDark() && image.getPixel(right + offsetX, top).isDark() &&
+                    (topMidIsDark || overallBlackPixels > 9)
+                ) -> {
+                intArrayOf(blackColor, blackColor, whiteColor, whiteColor)
+            }
+            bottomIsBlackStreak || (
+                botLeftIsDark && botRightIsDark &&
+                    image.getPixel(left - offsetX, bot).isDark() && image.getPixel(right + offsetX, bot).isDark() &&
+                    (bottomCenterPixel.isDark() || overallBlackPixels > 9)
+                ) -> {
+                intArrayOf(whiteColor, whiteColor, blackColor, blackColor)
+            }
+            else -> {
+                return ColorDrawable(whiteColor)
+            }
         }
-        return ColorDrawable(backgroundColor)
+
+        return GradientDrawable(
+            GradientDrawable.Orientation.TOP_BOTTOM,
+            gradient
+        )
     }
 
     private fun Int.isDark(): Boolean =

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -1,14 +1,25 @@
 package eu.kanade.tachiyomi.util.system
 
+import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import androidx.core.graphics.alpha
+import androidx.core.graphics.blue
 import androidx.core.graphics.createBitmap
+import androidx.core.graphics.green
+import androidx.core.graphics.red
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URLConnection
+import kotlin.math.abs
 
 object ImageUtil {
 
@@ -153,4 +164,215 @@ object ImageUtil {
     enum class Side {
         RIGHT, LEFT
     }
+
+    fun chooseBackground(context: Context, imageStream: InputStream): Drawable {
+        imageStream.mark(imageStream.available() + 1)
+
+        val image = BitmapFactory.decodeStream(imageStream)
+
+        imageStream.reset()
+
+        val backgroundColor = Color.WHITE
+        if (image == null) return ColorDrawable(backgroundColor)
+        if (image.width < 50 || image.height < 50) {
+            return ColorDrawable(backgroundColor)
+        }
+
+        val top = 5
+        val bot = image.height - 5
+        val left = (image.width * 0.0275).toInt()
+        val right = image.width - left
+        val midX = image.width / 2
+        val midY = image.height / 2
+        val offsetX = (image.width * 0.01).toInt()
+
+        val topLeftPixel = image.getPixel(left, top)
+        val topRightPixel = image.getPixel(right, top)
+        val midLeftPixel = image.getPixel(left, midY)
+        val midRightPixel = image.getPixel(right, midY)
+        val topCenterPixel = image.getPixel(midX, top)
+        val botLeftPixel = image.getPixel(left, bot)
+        val bottomCenterPixel = image.getPixel(midX, bot)
+        val botRightPixel = image.getPixel(right, bot)
+
+        val topLeftIsDark = topLeftPixel.isDark()
+        val topRightIsDark = topRightPixel.isDark()
+        val midLeftIsDark = midLeftPixel.isDark()
+        val midRightIsDark = midRightPixel.isDark()
+        val topMidIsDark = topCenterPixel.isDark()
+        val botLeftIsDark = botLeftPixel.isDark()
+        val botRightIsDark = botRightPixel.isDark()
+
+        var darkBG = (topLeftIsDark && (botLeftIsDark || botRightIsDark || topRightIsDark || midLeftIsDark || topMidIsDark)) ||
+            (topRightIsDark && (botRightIsDark || botLeftIsDark || midRightIsDark || topMidIsDark))
+
+        if (!topLeftPixel.isWhite() && topLeftPixel.isCloseTo(topCenterPixel) &&
+            !topCenterPixel.isWhite() && topCenterPixel.isCloseTo(topRightPixel) &&
+            !topRightPixel.isWhite() && topRightPixel.isCloseTo(botRightPixel) &&
+            !botRightPixel.isWhite() && botRightPixel.isCloseTo(bottomCenterPixel) &&
+            !bottomCenterPixel.isWhite() && bottomCenterPixel.isCloseTo(botLeftPixel) &&
+            !botLeftPixel.isWhite() && botLeftPixel.isCloseTo(topLeftPixel)
+        ) {
+            return ColorDrawable(topLeftPixel)
+        }
+
+        val whiteCorners = listOf(
+            topLeftPixel.isWhite(),
+            topRightPixel.isWhite(),
+            botLeftPixel.isWhite(),
+            botRightPixel.isWhite()
+        ).filter { it }
+
+        if (whiteCorners.size > 2) {
+            darkBG = false
+        }
+
+        var blackPixel = when {
+            topLeftIsDark -> topLeftPixel
+            topRightIsDark -> topRightPixel
+            botLeftIsDark -> botLeftPixel
+            botRightIsDark -> botRightPixel
+            else -> backgroundColor
+        }
+
+        var overallWhitePixels = 0
+        var overallBlackPixels = 0
+        var topBlackStreak = 0
+        var topWhiteStreak = 0
+        var botBlackStreak = 0
+        var botWhiteStreak = 0
+        outer@ for (x in intArrayOf(left, right, left - offsetX, right + offsetX)) {
+            var whitePixelsStreak = 0
+            var whitePixels = 0
+            var blackPixelsStreak = 0
+            var blackPixels = 0
+            var blackStreak = false
+            var whiteStreak = false
+            val notOffset = x == left || x == right
+            for ((index, y) in (0 until image.height step image.height / 25).withIndex()) {
+                val pixel = image.getPixel(x, y)
+                val pixelOff = image.getPixel(x + (if (x < image.width / 2) -offsetX else offsetX), y)
+                if (pixel.isWhite()) {
+                    whitePixelsStreak++
+                    whitePixels++
+                    if (notOffset) {
+                        overallWhitePixels++
+                    }
+                    if (whitePixelsStreak > 14) {
+                        whiteStreak = true
+                    }
+                    if (whitePixelsStreak > 6 && whitePixelsStreak >= index - 1) {
+                        topWhiteStreak = whitePixelsStreak
+                    }
+                } else {
+                    whitePixelsStreak = 0
+                    if (pixel.isDark() && pixelOff.isDark()) {
+                        blackPixels++
+                        if (notOffset) {
+                            overallBlackPixels++
+                        }
+                        blackPixelsStreak++
+                        if (blackPixelsStreak >= 14) {
+                            blackStreak = true
+                        }
+                        continue
+                    }
+                }
+                if (blackPixelsStreak > 6 && blackPixelsStreak >= index - 1) {
+                    topBlackStreak = blackPixelsStreak
+                }
+                blackPixelsStreak = 0
+            }
+            if (blackPixelsStreak > 6) {
+                botBlackStreak = blackPixelsStreak
+            } else if (whitePixelsStreak > 6) {
+                botWhiteStreak = whitePixelsStreak
+            }
+            when {
+                blackPixels > 22 -> {
+                    if (x == right || x == right + offsetX) {
+                        blackPixel = when {
+                            topRightIsDark -> topRightPixel
+                            botRightIsDark -> botRightPixel
+                            else -> blackPixel
+                        }
+                    }
+                    darkBG = true
+                    overallWhitePixels = 0
+                    break@outer
+                }
+                blackStreak -> {
+                    darkBG = true
+                    if (x == right || x == right + offsetX) {
+                        blackPixel = when {
+                            topRightIsDark -> topRightPixel
+                            botRightIsDark -> botRightPixel
+                            else -> blackPixel
+                        }
+                    }
+                    if (blackPixels > 18) {
+                        overallWhitePixels = 0
+                        break@outer
+                    }
+                }
+                whiteStreak || whitePixels > 22 -> darkBG = false
+            }
+        }
+
+        val topIsBlackStreak = topBlackStreak > topWhiteStreak
+        val bottomIsBlackStreak = botBlackStreak > botWhiteStreak
+        if (overallWhitePixels > 9 && overallWhitePixels > overallBlackPixels) {
+            darkBG = false
+        }
+        if (topIsBlackStreak && bottomIsBlackStreak) {
+            darkBG = true
+        }
+        val isLandscape = context.resources.configuration?.orientation == Configuration.ORIENTATION_LANDSCAPE
+        if (darkBG) {
+            return if (!isLandscape && botLeftPixel.isWhite() && botRightPixel.isWhite()) GradientDrawable(
+                    GradientDrawable.Orientation.TOP_BOTTOM,
+                    intArrayOf(blackPixel, blackPixel, backgroundColor, backgroundColor)
+            )
+            else if (!isLandscape && topLeftPixel.isWhite() && topRightPixel.isWhite()) GradientDrawable(
+                    GradientDrawable.Orientation.TOP_BOTTOM,
+                    intArrayOf(backgroundColor, backgroundColor, blackPixel, blackPixel)
+            )
+            else ColorDrawable(blackPixel)
+        }
+        if (!isLandscape && (
+                        topIsBlackStreak || (
+                                topLeftIsDark && topRightIsDark &&
+                                        image.getPixel(left - offsetX, top).isDark() && image.getPixel(right + offsetX, top).isDark() &&
+                                        (topMidIsDark || overallBlackPixels > 9)
+                                )
+                        )
+        ) {
+            return GradientDrawable(
+                    GradientDrawable.Orientation.TOP_BOTTOM,
+                    intArrayOf(blackPixel, blackPixel, backgroundColor, backgroundColor)
+            )
+        } else if (!isLandscape && (
+                        bottomIsBlackStreak || (
+                                botLeftIsDark && botRightIsDark &&
+                                        image.getPixel(left - offsetX, bot).isDark() && image.getPixel(right + offsetX, bot).isDark() &&
+                                        (bottomCenterPixel.isDark() || overallBlackPixels > 9)
+                                )
+                        )
+        ) {
+            return GradientDrawable(
+                    GradientDrawable.Orientation.TOP_BOTTOM,
+                    intArrayOf(backgroundColor, backgroundColor, blackPixel, blackPixel)
+            )
+        }
+        return ColorDrawable(backgroundColor)
+    }
+
+    private fun Int.isDark(): Boolean =
+        red < 40 && blue < 40 && green < 40 && alpha > 200
+
+    private fun Int.isCloseTo(other: Int): Boolean =
+        abs(red - other.red) < 30 && abs(green - other.green) < 30 && abs(blue - other.blue) < 30
+
+    private fun Int.isWhite(): Boolean =
+        red + blue + green > 740
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -13,12 +13,14 @@
         <item>@string/black_background</item>
         <item>@string/gray_background</item>
         <item>@string/white_background</item>
+        <item>@string/automatic_background</item>
     </string-array>
 
     <string-array name="reader_themes_values">
         <item>1</item>
         <item>2</item>
         <item>0</item>
+        <item>3</item>
     </string-array>
 
     <string-array name="image_scale_type">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,7 @@
     <string name="white_background">White</string>
     <string name="gray_background">Gray</string>
     <string name="black_background">Black</string>
+    <string name="automatic_background">Automatic</string>
     <string name="pref_viewer_type">Default reading mode</string>
     <string name="default_viewer">Default</string>
     <string name="default_nav">Default</string>


### PR DESCRIPTION
closes #584

This adds J2K implementation of automatic background color, which was the more preferable implementation https://github.com/tachiyomiorg/tachiyomi/issues/584#issuecomment-827070474

The implementation differs a little bit like it doesn't have J2K feature `Smart (by theme)`. Changed many of the `getPixel` function calls to be in variables instead. Also tweaked the code a little bit but it works the same way.

WebtoonViewer will see that `Automatic` is selected but it will use `Black`

**WARNING: THE VIDEO CONTAINS SOME NSFW CONTENT**

https://user-images.githubusercontent.com/6576096/116786783-d7fb6c00-aaa0-11eb-9d8b-9821799fc550.mp4

^Left is Tachiyomi and right is J2K, using the same implementation