### PR TITLE
Fix unofficial extensions being labeled as "Obsolete" instead of "Unofficial"

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
@@ -35,8 +35,8 @@ class ExtensionHolder(view: View, val adapter: ExtensionAdapter) :
         binding.lang.text = LocaleHelper.getSourceDisplayName(extension.lang, itemView.context)
         binding.warning.text = when {
             extension is Extension.Untrusted -> itemView.context.getString(R.string.ext_untrusted)
-            extension is Extension.Installed && extension.isObsolete -> itemView.context.getString(R.string.ext_obsolete)
             extension is Extension.Installed && extension.isUnofficial -> itemView.context.getString(R.string.ext_unofficial)
+            extension is Extension.Installed && extension.isObsolete -> itemView.context.getString(R.string.ext_obsolete)
             extension.isNsfw && shouldLabelNsfw -> itemView.context.getString(R.string.ext_nsfw_short)
             else -> ""
         }.toUpperCase()


### PR DESCRIPTION
This PR addresses a small, purely visual issue in the extension browser that due to the ordering of the statements in a "when" clause in ExtensionHolder.kt, an unofficial extension's label will read "OBSOLETE", when it should read "UNOFFICIAL"



Before:
![before-fix](https://user-images.githubusercontent.com/25621728/118582345-6550e880-b750-11eb-957a-d4f5937fb358.png)

After:
![after-fix](https://user-images.githubusercontent.com/25621728/118582366-6e41ba00-b750-11eb-9a7b-bf112552433d.png)

