### PR TITLE
Reinstate Proguard/R8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,15 @@ android {
         named("debug") {
             versionNameSuffix = "-${getCommitCount()}"
             applicationIdSuffix = ".debug"
+
+            isShrinkResources = true
+            isMinifyEnabled = true
+            proguardFiles("proguard-android-optimize.txt", "proguard-rules.pro")
+        }
+        create("debugFull") { // Debug without R8
+            initWith(getByName("debug"))
+            isShrinkResources = false
+            isMinifyEnabled = false
         }
         named("release") {
             isShrinkResources = true
@@ -63,14 +72,15 @@ android {
         }
     }
 
+    sourceSets {
+        getByName("debugFull").res.srcDirs("src/debug/res")
+    }
+
     flavorDimensions("default")
 
     productFlavors {
         create("standard") {
             buildConfigField("boolean", "INCLUDE_UPDATER", "true")
-            dimension = "default"
-        }
-        create("fdroid") {
             dimension = "default"
         }
         create("dev") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,15 +57,9 @@ android {
             applicationIdSuffix = ".debug"
         }
         named("release") {
-            /*named("postprocessing") {
-                postprocessing {
-                    isObfuscate = false
-                    isOptimizeCode = true
-                    isRemoveUnusedCode = false
-                    isRemoveUnusedResources = true
-                }
-                setProguardFiles(listOf(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"))
-            }*/
+            isShrinkResources = true
+            isMinifyEnabled = true
+            proguardFiles("proguard-android-optimize.txt", "proguard-rules.pro")
         }
     }
 

--- a/app/proguard-android-optimize.txt
+++ b/app/proguard-android-optimize.txt
@@ -1,0 +1,34 @@
+-allowaccessmodification
+-dontusemixedcaseclassnames
+-verbose
+
+-keepattributes *Annotation*
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers class * implements android.os.Parcelable {
+  public static final ** CREATOR;
+}
+
+-keep class androidx.annotation.Keep
+
+-keep @androidx.annotation.Keep class * {*;}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <methods>;
+}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <fields>;
+}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <init>(...);
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,29 +1,16 @@
 -dontobfuscate
 
-# Extensions may require methods unused in the core app
--dontwarn eu.kanade.tachiyomi.**
--keep class eu.kanade.tachiyomi.** { public protected private *; }
+# Keep extension's common dependencies
+-keep,allowoptimization class eu.kanade.tachiyomi.** { public protected *; }
+-keep,allowoptimization class kotlin.** { public protected *; }
+-keep,allowoptimization class okhttp3.** { public protected *; }
+-keep,allowoptimization class rx.** { public protected *; }
+-keep,allowoptimization class org.jsoup.** { public protected *; }
+-keep,allowoptimization class com.google.gson.** { public protected *; }
+-keep,allowoptimization class com.github.salomonbrys.kotson.** { public protected *; }
+-keep,allowoptimization class com.squareup.duktape.** { public protected *; }
 
--keep class org.jsoup.** { *; }
--keep class kotlin.** { *; }
--keep class okhttp3.** { *; }
--keep class com.google.gson.** { *; }
--keep class com.github.salomonbrys.kotson.** { *; }
--keep class com.squareup.duktape.** { *; }
-
-# Design library
--dontwarn com.google.android.material.**
--keep class com.google.android.material.** { *; }
--keep interface com.google.android.material.** { *; }
--keep public class com.google.android.material.R$* { *; }
-
--keep class com.hippo.image.** { *; }
--keep interface com.hippo.image.** { *; }
--keepclassmembers class * extends nucleus.presenter.Presenter {
-    <init>();
-}
-
-# RxJava 1.1.0
+##---------------Begin: proguard configuration for RxJava 1.x  ----------
 -dontwarn sun.misc.**
 
 -keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
@@ -39,30 +26,38 @@
     rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }
 
-# ReactiveNetwork
--dontwarn com.github.pwittchen.reactivenetwork.**
+-dontnote rx.internal.util.PlatformDependent
+##---------------End: proguard configuration for RxJava 1.x  ----------
 
-## GSON ##
-
+##---------------Begin: proguard configuration for Gson  ----------
 # Gson uses generic type information stored in a class file when working with fields. Proguard
 # removes such information by default, so configure it to keep all of it.
 -keepattributes Signature
 
-# Gson specific classes
--keep class sun.misc.Unsafe { *; }
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
 
-# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# Gson specific classes
+-dontwarn sun.misc.**
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
 
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+##---------------End: proguard configuration for Gson  ----------
 
-## kotlinx.serialization ##
-
+##---------------Begin: proguard configuration for Kotlin Serializer  ----------
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations
 
+# kotlinx-serialization-json specific. Add this if you have java.lang.NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializer
 -keepclassmembers class kotlinx.serialization.json.** {
     *** Companion;
 }
@@ -77,3 +72,4 @@
 -keepclasseswithmembers class eu.kanade.tachiyomi.** {
     kotlinx.serialization.KSerializer serializer(...);
 }
+##---------------End: proguard configuration for Kotlin Serializer  ----------


### PR DESCRIPTION
These are month old stats but it should be similar.
According to APK analyzer
Before: 18044 classes with 113387 methods in 3 dex files
After: 12604 classes with 68010 methods in 2 dex files
APK download size is reduced by 2.8 MB

And I believe this should also be enabled on preview builds, but it uses debug build type so we can either make a new build type for previews with R8 enabled or a separate debug build type with R8 disabled.