### PR TITLE
Matches tab ripple color with bottom nav

### DIFF
--- a/app/src/main/res/layout/common_tabbed_sheet.xml
+++ b/app/src/main/res/layout/common_tabbed_sheet.xml
@@ -24,7 +24,7 @@
             app:tabGravity="fill"
             app:tabIndicatorColor="?attr/colorAccent"
             app:tabMode="fixed"
-            app:tabRippleColor="?attr/rippleColor"
+            app:tabRippleColor="?attr/rippleNavColor"
             app:tabTextColor="@color/tabs_selector_background" />
 
         <ImageButton

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -25,7 +25,8 @@
             android:id="@+id/tabs"
             style="@style/Theme.Widget.Tabs"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            app:tabRippleColor="?attr/rippleNavColor" />
 
         <FrameLayout
             android:id="@+id/downloaded_only"

--- a/app/src/main/res/layout/main_activity_toolbar.xml
+++ b/app/src/main/res/layout/main_activity_toolbar.xml
@@ -20,7 +20,7 @@
         style="@style/Theme.Widget.Tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:tabRippleColor="?attr/rippleColor" />
+        app:tabRippleColor="?attr/rippleNavColor" />
 
     <FrameLayout
         android:id="@+id/downloaded_only"


### PR DESCRIPTION
Does what Google apps does, uses the colored ripple for Tabs as well and not just bottom nav.

| New | Old |
| ----- | ---- |
| ![new](https://user-images.githubusercontent.com/10836780/119239708-1c7fa200-bb4b-11eb-9157-eadab2159d25.png) | ![old](https://user-images.githubusercontent.com/10836780/119239785-9fa0f800-bb4b-11eb-8f9f-b2df03edd59b.png) |