### PR TITLE
Ripples patch

### DIFF
--- a/app/src/main/res/drawable/ripple_background.xml
+++ b/app/src/main/res/drawable/ripple_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="?attr/rippleColor">
-    <item android:drawable="@color/backgroundDark" />
+    <item android:drawable="?android:attr/colorBackground" />
 </ripple>

--- a/app/src/main/res/drawable/ripple_light.xml
+++ b/app/src/main/res/drawable/ripple_light.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?attr/rippleColor">
-    <item android:drawable="@color/backgroundLight" />
-</ripple>

--- a/app/src/main/res/layout/common_tabbed_sheet.xml
+++ b/app/src/main/res/layout/common_tabbed_sheet.xml
@@ -24,7 +24,6 @@
             app:tabGravity="fill"
             app:tabIndicatorColor="?attr/colorAccent"
             app:tabMode="fixed"
-            app:tabRippleColor="?attr/rippleNavColor"
             app:tabTextColor="@color/tabs_selector_background" />
 
         <ImageButton

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -25,8 +25,7 @@
             android:id="@+id/tabs"
             style="@style/Theme.Widget.Tabs"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:tabRippleColor="?attr/rippleNavColor" />
+            android:layout_height="wrap_content" />
 
         <FrameLayout
             android:id="@+id/downloaded_only"

--- a/app/src/main/res/layout/main_activity_toolbar.xml
+++ b/app/src/main/res/layout/main_activity_toolbar.xml
@@ -19,8 +19,7 @@
         android:id="@+id/tabs"
         style="@style/Theme.Widget.Tabs"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:tabRippleColor="?attr/rippleNavColor" />
+        android:layout_height="wrap_content" />
 
     <FrameLayout
         android:id="@+id/downloaded_only"

--- a/app/src/main/res/layout/manga_info_header.xml
+++ b/app/src/main/res/layout/manga_info_header.xml
@@ -144,8 +144,7 @@
             app:icon="@drawable/ic_favorite_border_24dp"
             app:layout_constraintEnd_toStartOf="@+id/btn_tracking"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/manga_info"
-            app:rippleColor="?attr/rippleColor" />
+            app:layout_constraintTop_toBottomOf="@+id/manga_info" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_tracking"
@@ -158,7 +157,6 @@
             app:layout_constraintEnd_toStartOf="@+id/btn_webview"
             app:layout_constraintStart_toEndOf="@+id/btn_favorite"
             app:layout_constraintTop_toBottomOf="@+id/manga_info"
-            app:rippleColor="?attr/rippleColor"
             tools:visibility="visible" />
 
         <com.google.android.material.button.MaterialButton
@@ -173,7 +171,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/btn_tracking"
             app:layout_constraintTop_toBottomOf="@+id/manga_info"
-            app:rippleColor="?attr/rippleColor"
             tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/pref_about_links.xml
+++ b/app/src/main/res/layout/pref_about_links.xml
@@ -16,8 +16,7 @@
         android:maxLines="1"
         android:text="@string/website"
         app:icon="@drawable/ic_public_24dp"
-        app:iconTint="?attr/colorAccent"
-        app:rippleColor="?attr/rippleColor" />
+        app:iconTint="?attr/colorAccent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_discord"
@@ -30,7 +29,6 @@
         android:text="Discord"
         app:icon="@drawable/ic_discord_24dp"
         app:iconTint="?attr/colorAccent"
-        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -44,7 +42,6 @@
         android:text="Twitter"
         app:icon="@drawable/ic_twitter_24dp"
         app:iconTint="?attr/colorAccent"
-        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -58,7 +55,6 @@
         android:text="Facebook"
         app:icon="@drawable/ic_facebook_24dp"
         app:iconTint="?attr/colorAccent"
-        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -72,7 +68,6 @@
         android:text="GitHub"
         app:icon="@drawable/ic_github_24dp"
         app:iconTint="?attr/colorAccent"
-        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/pref_about_links.xml
+++ b/app/src/main/res/layout/pref_about_links.xml
@@ -16,7 +16,8 @@
         android:maxLines="1"
         android:text="@string/website"
         app:icon="@drawable/ic_public_24dp"
-        app:iconTint="?attr/colorAccent" />
+        app:iconTint="?attr/colorAccent"
+        app:rippleColor="?attr/rippleColor" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_discord"
@@ -29,6 +30,7 @@
         android:text="Discord"
         app:icon="@drawable/ic_discord_24dp"
         app:iconTint="?attr/colorAccent"
+        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -42,6 +44,7 @@
         android:text="Twitter"
         app:icon="@drawable/ic_twitter_24dp"
         app:iconTint="?attr/colorAccent"
+        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -55,6 +58,7 @@
         android:text="Facebook"
         app:icon="@drawable/ic_facebook_24dp"
         app:iconTint="?attr/colorAccent"
+        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
@@ -68,6 +72,7 @@
         android:text="GitHub"
         app:icon="@drawable/ic_github_24dp"
         app:iconTint="?attr/colorAccent"
+        app:rippleColor="?attr/rippleColor"
         tools:ignore="HardcodedText" />
 
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -370,12 +370,8 @@
     <!--===============-->
     <!--Custom Selector-->
     <!--===============-->
-    <style name="PreferenceThemeLight" parent="@style/PreferenceThemeOverlay">
-        <item name="android:selectableItemBackground">@drawable/ripple_light</item>
-    </style>
-
-    <style name="PreferenceThemeDark" parent="@style/PreferenceThemeOverlay">
-        <item name="android:selectableItemBackground">@drawable/ripple_dark</item>
+    <style name="PreferenceThemeCustom" parent="@style/PreferenceThemeOverlay">
+        <item name="android:selectableItemBackground">@drawable/ripple_background</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -308,6 +308,7 @@
         <item name="android:textAllCaps">false</item>
 
         <item name="backgroundTint">@android:color/transparent</item>
+        <item name="rippleColor">?attr/rippleColor</item>
 
         <item name="iconGravity">top</item>
         <item name="iconTint">@color/button_action_selector</item>
@@ -347,6 +348,7 @@
         <item name="tabMinWidth">75dp</item>
         <item name="tabMode">scrollable</item>
         <item name="tabTextAppearance">@style/TextAppearance.Widget.Tab</item>
+        <item name="tabRippleColor">?attr/rippleNavColor</item>
     </style>
 
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -59,7 +59,7 @@
         <item name="actionModeCloseDrawable">@drawable/ic_close_24dp</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="toolbarNavigationButtonStyle">@style/Theme.Toolbar.Navigation</item>
-        <item name="preferenceTheme">@style/PreferenceThemeLight</item>
+        <item name="preferenceTheme">@style/PreferenceThemeCustom</item>
         <item name="dialogTheme">@style/Theme.AlertDialog.Light</item>
         <item name="materialAlertDialogTheme">@style/Theme.AlertDialog.Light</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>
@@ -157,7 +157,7 @@
         <item name="actionBarTheme">@style/Theme.Toolbar.Custom</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="toolbarNavigationButtonStyle">@style/Theme.Toolbar.Navigation</item>
-        <item name="preferenceTheme">@style/PreferenceThemeDark</item>
+        <item name="preferenceTheme">@style/PreferenceThemeCustom</item>
         <item name="dialogTheme">@style/Theme.AlertDialog.Dark</item>
         <item name="materialAlertDialogTheme">@style/Theme.AlertDialog.Dark</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -104,6 +104,7 @@
         <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
         <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
         <item name="colorFilterActive">@color/filterColorDark</item>
+        <item name="rippleNavColor">@color/md_white_1000_6</item>
         <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
@@ -193,6 +194,8 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
         <item name="colorPrimaryVariant">@color/colorPrimary</item>
+
+        <item name="rippleNavColor">@color/md_white_1000_6</item>
     </style>
 
     <style name="Theme.Tachiyomi.Dark.Amoled">


### PR DESCRIPTION
- Added override for `rippleNavColor` for the Dark Blue and Light Blue themes, now doesn't blend in.
- Fixed so background for Settings used background color, meaning it fixes AMOLED.
- About icons now uses Ripples too, since it was added to the main Style instead.