### PR TITLE
Create a toolbar variable for ripples

### DIFF
--- a/app/src/main/res/layout-sw600dp/main_activity.xml
+++ b/app/src/main/res/layout-sw600dp/main_activity.xml
@@ -76,7 +76,7 @@
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             app:itemIconTint="@color/nav_selector"
-            app:itemRippleColor="?attr/rippleNavColor"
+            app:itemRippleColor="?attr/rippleSecondaryColor"
             app:itemTextColor="@color/nav_selector"
             app:labelVisibilityMode="labeled"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -82,7 +82,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         app:itemIconTint="@color/nav_selector"
-        app:itemRippleColor="?attr/rippleNavColor"
+        app:itemRippleColor="?attr/rippleSecondaryColor"
         app:itemTextColor="@color/nav_selector"
         app:labelVisibilityMode="labeled"
         app:layout_insetEdge="bottom"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -23,5 +23,6 @@
     <attr name="colorBackgroundSplash" format="reference|integer"/>
     <attr name="colorAccentOnPrimary" format="reference|integer"/>
     <attr name="rippleSecondaryColor" format="reference|integer"/>
+    <attr name="rippleToolbarColor" format="reference|integer"/>
 
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -22,6 +22,6 @@
     <attr name="colorFilterActive" format="reference|integer"/>
     <attr name="colorBackgroundSplash" format="reference|integer"/>
     <attr name="colorAccentOnPrimary" format="reference|integer"/>
-    <attr name="rippleNavColor" format="reference|integer"/>
+    <attr name="rippleSecondaryColor" format="reference|integer"/>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="textColorHintLight">@color/md_black_1000_38</color>
     <color name="dividerLight">@color/md_black_1000_12</color>
     <color name="rippleColorLight">@color/md_black_1000_6</color>
-    <color name="rippleNavColorLight">@color/md_blue_A400_4</color>
+    <color name="rippleSecondaryColorLight">@color/md_blue_A400_4</color>
     <color name="backgroundLight">@color/md_grey_50</color>
     <color name="dialogLight">@color/md_white_1000</color>
     <color name="selectorColorLight">@color/md_blue_A400_38</color>
@@ -31,7 +31,7 @@
     <color name="textColorHintDark">@color/md_white_1000_50</color>
     <color name="dividerDark">@android:color/transparent</color>
     <color name="rippleColorDark">@color/md_white_1000_6</color>
-    <color name="rippleNavColorDark">#0A3399FF</color>
+    <color name="rippleSecondaryColorDark">#0A3399FF</color>
     <color name="backgroundDark">@color/colorDarkPrimaryDark</color>
     <color name="dialogDark">@color/colorDarkPrimary</color>
     <color name="selectorColorDark">@color/md_blue_A200_50</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,6 +20,7 @@
     <color name="dividerLight">@color/md_black_1000_12</color>
     <color name="rippleColorLight">@color/md_black_1000_6</color>
     <color name="rippleSecondaryColorLight">@color/md_blue_A400_4</color>
+    <color name="rippleToolbarColorLight">@color/rippleColorLight</color>
     <color name="backgroundLight">@color/md_grey_50</color>
     <color name="dialogLight">@color/md_white_1000</color>
     <color name="selectorColorLight">@color/md_blue_A400_38</color>
@@ -32,6 +33,7 @@
     <color name="dividerDark">@android:color/transparent</color>
     <color name="rippleColorDark">@color/md_white_1000_6</color>
     <color name="rippleSecondaryColorDark">#0A3399FF</color>
+    <color name="rippleToolbarColorDark">@color/rippleColorDark</color>
     <color name="backgroundDark">@color/colorDarkPrimaryDark</color>
     <color name="dialogDark">@color/colorDarkPrimary</color>
     <color name="selectorColorDark">@color/md_blue_A200_50</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -296,7 +296,7 @@
     <!--==============-->
     <style name="Theme.Widget.Button" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">?attr/colorAccent</item>
-        <item name="rippleColor">?attr/rippleColor</item>
+        <item name="rippleColor">?attr/rippleSecondaryColor</item>
         <item name="android:textAllCaps">false</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,12 +6,16 @@
     <!--========-->
     <style name="Theme.Toolbar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar" />
 
-    <style name="Theme.Toolbar.Light" parent="Theme.Toolbar.Custom">
+    <style name="Theme.Toolbar.Light" parent="Theme.Toolbar.Custom.Dark">
         <item name="popupTheme">@style/ThemeOverlay.MaterialComponents.Light</item>
     </style>
 
-    <style name="Theme.Toolbar.Custom" parent="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
-        <item name="android:colorControlHighlight">?attr/rippleColor</item>
+    <style name="Theme.Toolbar.Custom" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="android:colorControlHighlight">?attr/rippleToolbarColor</item>
+    </style>
+
+    <style name="Theme.Toolbar.Custom.Dark" parent="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
+        <item name="android:colorControlHighlight">?attr/rippleToolbarColor</item>
     </style>
 
     <style name="Theme.Toolbar.Navigation" parent="Widget.AppCompat.Toolbar.Button.Navigation">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -348,7 +348,7 @@
         <item name="tabMinWidth">75dp</item>
         <item name="tabMode">scrollable</item>
         <item name="tabTextAppearance">@style/TextAppearance.Widget.Tab</item>
-        <item name="tabRippleColor">?attr/rippleNavColor</item>
+        <item name="tabRippleColor">?attr/rippleSecondaryColor</item>
     </style>
 
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,12 +37,12 @@
         <item name="android:textColorSecondaryInverse">@color/textColorSecondaryDark</item>
         <item name="android:textColorHintInverse">@color/textColorHintDark</item>
         <item name="rippleColor">@color/rippleColorLight</item>
-        <item name="rippleNavColor">@color/rippleNavColorLight</item>
         <item name="android:colorEdgeEffect">?attr/colorAccent</item>
 
         <item name="android:divider">@color/dividerLight</item>
         <item name="android:listDivider">@drawable/line_divider</item>
 
+        <item name="rippleSecondaryColor">@color/rippleSecondaryColorLight</item>
         <!-- Handles RTL text -->
         <item name="android:textAlignment">gravity</item>
         <item name="android:textDirection">locale</item>
@@ -104,7 +104,7 @@
         <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
         <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
         <item name="colorFilterActive">@color/filterColorDark</item>
-        <item name="rippleNavColor">@color/md_white_1000_6</item>
+        <item name="rippleSecondaryColor">@color/md_white_1000_6</item>
         <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
@@ -138,13 +138,13 @@
         <item name="android:textColorPrimaryInverse">@color/textColorPrimaryLight</item>
         <item name="android:textColorSecondaryInverse">@color/textColorSecondaryLight</item>
         <item name="android:textColorHintInverse">@color/textColorHintLight</item>
-        <item name="rippleNavColor">@color/rippleNavColorDark</item>
         <item name="rippleColor">@color/rippleColorDark</item>
         <item name="android:colorEdgeEffect">?attr/colorAccent</item>
 
         <item name="android:divider">@color/dividerDark</item>
         <item name="android:listDivider">@drawable/line_divider</item>
 
+        <item name="rippleSecondaryColor">@color/rippleSecondaryColorDark</item>
         <!-- Themes -->
         <item name="android:statusBarColor">?attr/colorPrimary</item>
         <item name="android:navigationBarColor">?attr/colorPrimary</item>
@@ -194,8 +194,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
         <item name="colorPrimaryVariant">@color/colorPrimary</item>
-
-        <item name="rippleNavColor">@color/md_white_1000_6</item>
+        <item name="rippleSecondaryColor">@color/md_black_1000_6</item>
     </style>
 
     <style name="Theme.Tachiyomi.Dark.Amoled">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,13 +36,16 @@
         <item name="android:textColorPrimaryInverse">@color/textColorPrimaryDark</item>
         <item name="android:textColorSecondaryInverse">@color/textColorSecondaryDark</item>
         <item name="android:textColorHintInverse">@color/textColorHintDark</item>
-        <item name="rippleColor">@color/rippleColorLight</item>
         <item name="android:colorEdgeEffect">?attr/colorAccent</item>
 
         <item name="android:divider">@color/dividerLight</item>
         <item name="android:listDivider">@drawable/line_divider</item>
 
+        <!-- Ripples -->
+        <item name="rippleColor">@color/rippleColorLight</item>
         <item name="rippleSecondaryColor">@color/rippleSecondaryColorLight</item>
+        <item name="rippleToolbarColor">@color/rippleToolbarColorLight</item>
+
         <!-- Handles RTL text -->
         <item name="android:textAlignment">gravity</item>
         <item name="android:textDirection">locale</item>
@@ -57,6 +60,7 @@
         <item name="actionModeStyle">@style/Theme.ActionMode</item>
         <item name="actionModeCloseButtonStyle">@style/Theme.ActionMode.CloseButton</item>
         <item name="actionModeCloseDrawable">@drawable/ic_close_24dp</item>
+        <item name="actionBarTheme">@style/Theme.Toolbar.Custom</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="toolbarNavigationButtonStyle">@style/Theme.Toolbar.Navigation</item>
         <item name="preferenceTheme">@style/PreferenceThemeCustom</item>
@@ -105,6 +109,7 @@
         <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
         <item name="colorFilterActive">@color/filterColorDark</item>
         <item name="rippleSecondaryColor">@color/md_white_1000_6</item>
+        <item name="rippleToolbarColor">@color/md_white_1000_12</item>
         <item name="actionBarTheme">@style/Theme.Toolbar.Light</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
@@ -138,13 +143,16 @@
         <item name="android:textColorPrimaryInverse">@color/textColorPrimaryLight</item>
         <item name="android:textColorSecondaryInverse">@color/textColorSecondaryLight</item>
         <item name="android:textColorHintInverse">@color/textColorHintLight</item>
-        <item name="rippleColor">@color/rippleColorDark</item>
         <item name="android:colorEdgeEffect">?attr/colorAccent</item>
 
         <item name="android:divider">@color/dividerDark</item>
         <item name="android:listDivider">@drawable/line_divider</item>
 
+        <!-- Ripples -->
+        <item name="rippleColor">@color/rippleColorDark</item>
         <item name="rippleSecondaryColor">@color/rippleSecondaryColorDark</item>
+        <item name="rippleToolbarColor">@color/rippleToolbarColorDark</item>
+
         <!-- Themes -->
         <item name="android:statusBarColor">?attr/colorPrimary</item>
         <item name="android:navigationBarColor">?attr/colorPrimary</item>
@@ -155,7 +163,7 @@
         <item name="actionModeStyle">@style/Theme.ActionMode</item>
         <item name="actionModeCloseButtonStyle">@style/Theme.ActionMode.CloseButton</item>
         <item name="actionModeCloseDrawable">@drawable/ic_close_24dp</item>
-        <item name="actionBarTheme">@style/Theme.Toolbar.Custom</item>
+        <item name="actionBarTheme">@style/Theme.Toolbar.Custom.Dark</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="toolbarNavigationButtonStyle">@style/Theme.Toolbar.Navigation</item>
         <item name="preferenceTheme">@style/PreferenceThemeCustom</item>
@@ -195,6 +203,7 @@
         <item name="colorAccentOnPrimary">@color/textColorPrimaryDark</item>
         <item name="colorPrimaryVariant">@color/colorPrimary</item>
         <item name="rippleSecondaryColor">@color/md_black_1000_6</item>
+        <item name="rippleToolbarColor">@color/md_black_1000_12</item>
     </style>
 
     <style name="Theme.Tachiyomi.Dark.Amoled">
@@ -225,7 +234,7 @@
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <item name="android:navigationBarColor">?attr/colorPrimaryVariant</item>
 
-        <item name="actionBarTheme">@style/Theme.Toolbar.Custom</item>
+        <item name="actionBarTheme">@style/Theme.Toolbar.Custom.Dark</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="switchStyle">@style/Theme.Widget.BasicSwitch</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>
@@ -241,7 +250,7 @@
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <item name="android:navigationBarColor">?attr/colorPrimaryVariant</item>
 
-        <item name="actionBarTheme">@style/Theme.Toolbar.Custom</item>
+        <item name="actionBarTheme">@style/Theme.Toolbar.Custom.Dark</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="switchStyle">@style/Theme.Widget.BasicSwitch</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>


### PR DESCRIPTION
Creates a Toolbar variable for ripples so themes using a custom toolbar color (Like, Dark blue and Light blue) can have more distinct ripples.

Renames the rippleNavColor to rippleSecondaryColor as it's not just for navigation anymore.

Adds rippleSecondaryColor for some text buttons:
| New | Old |
| ----- | ----- |
| ![New](https://user-images.githubusercontent.com/10836780/119271444-d46f8680-bc01-11eb-91b2-64d9e86448ef.png) | ![Old](https://user-images.githubusercontent.com/10836780/119271440-d20d2c80-bc01-11eb-8aea-6c22ab5fbc9d.png) |