### PR TITLE
Background tracker update during Library update

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -21,6 +21,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.data.track.UnattendedTrackService
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.SManga
@@ -210,14 +211,10 @@ class LibraryUpdateService(
             stopSelf(startId)
         }
         updateJob = ioScope.launch(handler) {
-            when {
-                target == Target.CHAPTERS && preferences.autoUpdateTrackers() -> {
-                    updateChapterList()
-                    updateTrackings()
-                }
-                target == Target.CHAPTERS -> updateChapterList()
-                target == Target.COVERS -> updateCovers()
-                target == Target.TRACKING -> updateTrackings()
+            when (target) {
+                Target.CHAPTERS -> updateChapterList()
+                Target.COVERS -> updateCovers()
+                Target.TRACKING -> updateTrackings()
             }
         }
         updateJob?.invokeOnCompletion { stopSelf(startId) }
@@ -277,6 +274,7 @@ class LibraryUpdateService(
         val newUpdates = mutableListOf<Pair<LibraryManga, Array<Chapter>>>()
         val failedUpdates = mutableListOf<Pair<Manga, String?>>()
         var hasDownloads = false
+        val loggedServices by lazy { trackManager.services.filter { it.isLogged } }
 
         mangaToUpdate.forEach { manga ->
             if (updateJob?.isActive != true) {
@@ -304,6 +302,10 @@ class LibraryUpdateService(
                     e.message
                 }
                 failedUpdates.add(manga to errorMessage)
+            }
+
+            if (preferences.autoUpdateTrackers()) {
+                updateTrackings(manga, loggedServices)
             }
         }
 
@@ -413,31 +415,35 @@ class LibraryUpdateService(
             notifier.showProgressNotification(manga, progressCount++, mangaToUpdate.size)
 
             // Update the tracking details.
-            db.getTracks(manga).executeAsBlocking()
-                .map { track ->
-                    supervisorScope {
-                        async {
-                            val service = trackManager.getService(track.sync_id)
-                            if (service != null && service in loggedServices) {
-                                try {
-                                    val updatedTrack = service.refresh(track)
-                                    db.insertTrack(updatedTrack).executeAsBlocking()
+            updateTrackings(manga, loggedServices)
+        }
 
-                                    if (service is UnattendedTrackService) {
-                                        syncChaptersWithTrackServiceTwoWay(db, db.getChapters(manga).executeAsBlocking(), track, service)
-                                    }
-                                } catch (e: Throwable) {
-                                    // Ignore errors and continue
-                                    Timber.e(e)
+        notifier.cancelProgressNotification()
+    }
+
+    private suspend fun updateTrackings(manga: LibraryManga, loggedServices: List<TrackService>) {
+        db.getTracks(manga).executeAsBlocking()
+            .map { track ->
+                supervisorScope {
+                    async {
+                        val service = trackManager.getService(track.sync_id)
+                        if (service != null && service in loggedServices) {
+                            try {
+                                val updatedTrack = service.refresh(track)
+                                db.insertTrack(updatedTrack).executeAsBlocking()
+
+                                if (service is UnattendedTrackService) {
+                                    syncChaptersWithTrackServiceTwoWay(db, db.getChapters(manga).executeAsBlocking(), track, service)
                                 }
+                            } catch (e: Throwable) {
+                                // Ignore errors and continue
+                                Timber.e(e)
                             }
                         }
                     }
                 }
-                .awaitAll()
-        }
-
-        notifier.cancelProgressNotification()
+            }
+            .awaitAll()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -210,10 +210,14 @@ class LibraryUpdateService(
             stopSelf(startId)
         }
         updateJob = ioScope.launch(handler) {
-            when (target) {
-                Target.CHAPTERS -> updateChapterList()
-                Target.COVERS -> updateCovers()
-                Target.TRACKING -> updateTrackings()
+            when {
+                target == Target.CHAPTERS && preferences.autoUpdateTrackers() -> launch {
+                    updateChapterList()
+                    updateTrackings()
+                }.join()
+                target == Target.CHAPTERS -> updateChapterList()
+                target == Target.COVERS -> updateCovers()
+                target == Target.TRACKING -> updateTrackings()
             }
         }
         updateJob?.invokeOnCompletion { stopSelf(startId) }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -211,10 +211,10 @@ class LibraryUpdateService(
         }
         updateJob = ioScope.launch(handler) {
             when {
-                target == Target.CHAPTERS && preferences.autoUpdateTrackers() -> launch {
+                target == Target.CHAPTERS && preferences.autoUpdateTrackers() -> {
                     updateChapterList()
                     updateTrackings()
-                }.join()
+                }
                 target == Target.CHAPTERS -> updateChapterList()
                 target == Target.COVERS -> updateCovers()
                 target == Target.TRACKING -> updateTrackings()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -166,6 +166,8 @@ object PreferenceKeys {
 
     const val autoUpdateMetadata = "auto_update_metadata"
 
+    const val autoUpdateTrackers = "auto_update_trackers"
+
     const val showLibraryUpdateErrors = "show_library_update_errors"
 
     const val downloadNew = "download_new"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -77,6 +77,8 @@ class PreferencesHelper(val context: Context) {
 
     fun autoUpdateMetadata() = prefs.getBoolean(Keys.autoUpdateMetadata, false)
 
+    fun autoUpdateTrackers() = prefs.getBoolean(Keys.autoUpdateTrackers, false)
+
     fun showLibraryUpdateErrors() = prefs.getBoolean(Keys.showLibraryUpdateErrors, false)
 
     fun clear() = prefs.edit { clear() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -239,6 +239,12 @@ class SettingsLibraryController : SettingsController() {
                 defaultValue = false
             }
             switchPreference {
+                key = Keys.autoUpdateTrackers
+                titleRes = R.string.pref_library_update_refresh_trackers
+                summaryRes = R.string.pref_library_update_refresh_trackers_summary
+                defaultValue = false
+            }
+            switchPreference {
                 key = Keys.showLibraryUpdateErrors
                 titleRes = R.string.pref_library_update_error_notification
                 defaultValue = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="pref_update_only_non_completed">Only update ongoing manga</string>
     <string name="pref_library_update_refresh_metadata">Automatically refresh metadata</string>
     <string name="pref_library_update_refresh_metadata_summary">Check for new cover and details when updating library</string>
+    <string name="pref_library_update_refresh_trackers">Automatically update trackers</string>
+    <string name="pref_library_update_refresh_trackers_summary">Update trackers when updating library</string>
     <string name="pref_library_update_error_notification">Show update errors notifications</string>
 
     <string name="default_category">Default category</string>


### PR DESCRIPTION
This adds a new preference in the Library screen to enable trackers update during Library update. It defaults to off. Should probably be merged after #5163 to avoid issues with AniList.