### PR TITLE
Fix incognito mode disabled after the app kicked out of memory

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -74,9 +74,6 @@ open class App : Application(), LifecycleObserver, ImageLoaderFactory {
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
 
-        // Reset Incognito Mode on relaunch
-        preferences.incognitoMode().set(false)
-
         // Show notification to disable Incognito Mode when it's enabled
         preferences.incognitoMode().asFlow()
             .onEach { enabled ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -224,6 +224,9 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
         syncActivityViewWithController(router.backstack.lastOrNull()?.controller())
 
         if (savedInstanceState == null) {
+            // Reset Incognito Mode on relaunch
+            preferences.incognitoMode().set(false)
+
             // Show changelog prompt on update
             if (Migrations.upgrade(preferences) && !BuildConfig.DEBUG) {
                 WhatsNewDialogController().showDialog(router)


### PR DESCRIPTION
The application class onCreate will also be called when user navigates to an
activity after the app process is killed by the system.

So make sure the incognito is disabled only when the entry point of the app is
created from scratch (e.g. after being force closed by the user).