### PR TITLE
Added radio buttons filter type (implementation) for browsing manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
@@ -20,7 +20,7 @@ sealed class Filter<T>(val name: String, var state: T) {
 
     abstract class Group<V>(name: String, state: List<V>) : Filter<List<V>>(name, state)
 
-    abstract class RadioGroup(name: String, val values: Array<String>) : Filter<Int>(name, 0)
+    abstract class RadioGroup(name: String, val values: Array<String>, state: Int = 0) : Filter<Int>(name, state)
 
     abstract class Sort(name: String, val values: Array<String>, state: Selection? = null) :
         Filter<Sort.Selection?>(name, state) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
@@ -20,6 +20,8 @@ sealed class Filter<T>(val name: String, var state: T) {
 
     abstract class Group<V>(name: String, state: List<V>) : Filter<List<V>>(name, state)
 
+    abstract class RadioGroup(name: String, val values: Array<String>) : Filter<Int>(name, 0)
+
     abstract class Sort(name: String, val values: Array<String>, state: Selection? = null) :
         Filter<Sort.Selection?>(name, state) {
         data class Selection(val index: Int, val ascending: Boolean)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/Filter.kt
@@ -20,7 +20,11 @@ sealed class Filter<T>(val name: String, var state: T) {
 
     abstract class Group<V>(name: String, state: List<V>) : Filter<List<V>>(name, state)
 
-    abstract class RadioGroup(name: String, val values: Array<String>, state: Int = 0) : Filter<Int>(name, state)
+    /*
+    This has been made a subclass of Select in order to keep backwards compatibility with old
+    Tachiyomi versions. Old versions using an extension with this filter will fall back to a Select dropdown
+     */
+    abstract class RadioGroup(name: String, values: Array<String>, state: Int = 0) : Select<String>(name, values, state)
 
     abstract class Sort(name: String, val values: Array<String>, state: Selection? = null) :
         Filter<Sort.Selection?>(name, state) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourcePresenter.kt
@@ -29,6 +29,8 @@ import eu.kanade.tachiyomi.ui.browse.source.filter.TextItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TextSectionItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TriStateItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TriStateSectionItem
+import eu.kanade.tachiyomi.ui.browse.source.filter.RadioGroupItem
+import eu.kanade.tachiyomi.ui.browse.source.filter.RadioItem
 import eu.kanade.tachiyomi.util.chapter.ChapterSettingsHelper
 import eu.kanade.tachiyomi.util.lang.launchIO
 import eu.kanade.tachiyomi.util.lang.withUIContext
@@ -309,6 +311,14 @@ open class BrowseSourcePresenter(
                     }
                     group.subItems = subItems
                     group
+                }
+                is Filter.RadioGroup -> {
+                    val radioGroup = RadioGroupItem(filter)
+                    val subItems = filter.values.map { value ->
+                        RadioItem(value, radioGroup)
+                    }
+                    radioGroup.subItems = subItems
+                    radioGroup
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourcePresenter.kt
@@ -20,6 +20,8 @@ import eu.kanade.tachiyomi.ui.browse.source.filter.CheckboxItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.CheckboxSectionItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.GroupItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.HeaderItem
+import eu.kanade.tachiyomi.ui.browse.source.filter.RadioGroupItem
+import eu.kanade.tachiyomi.ui.browse.source.filter.RadioItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.SelectItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.SelectSectionItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.SeparatorItem
@@ -29,8 +31,6 @@ import eu.kanade.tachiyomi.ui.browse.source.filter.TextItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TextSectionItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TriStateItem
 import eu.kanade.tachiyomi.ui.browse.source.filter.TriStateSectionItem
-import eu.kanade.tachiyomi.ui.browse.source.filter.RadioGroupItem
-import eu.kanade.tachiyomi.ui.browse.source.filter.RadioItem
 import eu.kanade.tachiyomi.util.chapter.ChapterSettingsHelper
 import eu.kanade.tachiyomi.util.lang.launchIO
 import eu.kanade.tachiyomi.util.lang.withUIContext
@@ -288,6 +288,14 @@ open class BrowseSourcePresenter(
                 is Filter.CheckBox -> CheckboxItem(filter)
                 is Filter.TriState -> TriStateItem(filter)
                 is Filter.Text -> TextItem(filter)
+                is Filter.RadioGroup -> {
+                    val radioGroup = RadioGroupItem(filter)
+                    val subItems = filter.values.map { value ->
+                        RadioItem(value, radioGroup)
+                    }
+                    radioGroup.subItems = subItems
+                    radioGroup
+                }
                 is Filter.Select<*> -> SelectItem(filter)
                 is Filter.Group<*> -> {
                     val group = GroupItem(filter)
@@ -311,14 +319,6 @@ open class BrowseSourcePresenter(
                     }
                     group.subItems = subItems
                     group
-                }
-                is Filter.RadioGroup -> {
-                    val radioGroup = RadioGroupItem(filter)
-                    val subItems = filter.values.map { value ->
-                        RadioItem(value, radioGroup)
-                    }
-                    radioGroup.subItems = subItems
-                    radioGroup
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/filter/RadioGroupItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/filter/RadioGroupItem.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.ui.browse.source.filter
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import eu.davidea.flexibleadapter.FlexibleAdapter
+import eu.davidea.flexibleadapter.items.AbstractExpandableHeaderItem
+import eu.davidea.flexibleadapter.items.IFlexible
+import eu.davidea.flexibleadapter.items.ISectionable
+import eu.davidea.viewholders.ExpandableViewHolder
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.util.view.setVectorCompat
+
+class RadioGroupItem(val filter: Filter.RadioGroup) : AbstractExpandableHeaderItem<RadioGroupItem.Holder, ISectionable<*, *>>() {
+
+    init {
+        isExpanded = false
+    }
+
+    override fun getLayoutRes(): Int {
+        return R.layout.navigation_view_group
+    }
+
+    override fun createViewHolder(view: View, adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>): Holder {
+        return Holder(view, adapter)
+    }
+
+    override fun bindViewHolder(adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>, holder: Holder, position: Int, payloads: List<Any?>?) {
+        holder.title.text = filter.name
+
+        holder.icon.setVectorCompat(
+            if (isExpanded) {
+                R.drawable.ic_expand_less_24dp
+            } else {
+                R.drawable.ic_expand_more_24dp
+            }
+        )
+
+        holder.itemView.setOnClickListener(holder)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return filter == (other as RadioGroupItem).filter
+    }
+
+    override fun hashCode(): Int {
+        return filter.hashCode()
+    }
+
+    open class Holder(view: View, adapter: FlexibleAdapter<*>) : ExpandableViewHolder(view, adapter, true) {
+        val title: TextView = itemView.findViewById(R.id.title)
+
+        val icon: ImageView = itemView.findViewById(R.id.expand_icon)
+
+        override fun shouldNotifyParentOnClick(): Boolean {
+            return true
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/filter/RadioItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/filter/RadioItem.kt
@@ -1,0 +1,60 @@
+package eu.kanade.tachiyomi.ui.browse.source.filter
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.radiobutton.MaterialRadioButton
+import eu.davidea.flexibleadapter.FlexibleAdapter
+import eu.davidea.flexibleadapter.items.*
+import eu.davidea.viewholders.FlexibleViewHolder
+import eu.kanade.tachiyomi.util.system.dpToPx
+import eu.kanade.tachiyomi.R as TR
+
+open class RadioItem(val name: String, private val radioGroup: RadioGroupItem) : AbstractSectionableItem<RadioItem.Holder, RadioGroupItem>(radioGroup) {
+
+    override fun getLayoutRes(): Int {
+        return TR.layout.navigation_view_radio
+    }
+
+    override fun createViewHolder(view: View, adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>): Holder {
+        return Holder(view, adapter)
+    }
+
+    override fun bindViewHolder(adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>, holder: Holder, position: Int, payloads: List<Any?>?) {
+        val filter = radioGroup.filter
+
+        val i = filter.values.indexOf(name)
+
+        val view = holder.text
+        view.text = filter.values[i]
+        view.isChecked = filter.state == i
+
+        // view.setCompoundDrawablesWithIntrinsicBounds(getIcon(), null, null, null)
+        holder.itemView.setOnClickListener {
+            filter.state = i
+            radioGroup.subItems.forEach { adapter.notifyItemChanged(adapter.getGlobalPositionOf(it)) }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as RadioItem
+        return name == other.name && radioGroup.filter == other.radioGroup.filter
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + radioGroup.hashCode()
+        return result
+    }
+
+    open class Holder(view: View, adapter: FlexibleAdapter<*>) : FlexibleViewHolder(view, adapter) {
+        val text: MaterialRadioButton = itemView.findViewById(TR.id.nav_view_item)
+
+        init {
+            // Align with native checkbox
+            text.setPadding(4.dpToPx, 0, 0, 0)
+            text.compoundDrawablePadding = 20.dpToPx
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR adds the app implementation of radio buttons as a type of filter that can be used to filter manga when browsing a source. This is intended to be an alternative to the Select filter, as sometimes it is not practical to use a drop-down for a large series of mutually exclusive options.

The RadioGroup filter acts similar to the Group or Sort filters, where a clickable header expands to show the available options. The filter's options are provided by an array of strings, and the filter's state is Int, indicating the index of the currently selected item.

# Preview

![radiofilter_preview](https://user-images.githubusercontent.com/25621728/119431242-74471600-bccf-11eb-835a-c62738872993.png)

# Addendum
- Since this PR is essentially a feature for extension developers, I realize that adaption of this feature would require an update to the extensions library as well in order to include the stub for the filter.
- The preview image was created by temporarily adding a RadioGroup filter to the Local Source, since it is the only usable source built into the core app.