### PR TITLE
Display the currently active restrictions in the library update preference

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -8,7 +8,9 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import eu.kanade.tachiyomi.data.preference.CHARGING
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.preference.UNMETERED_NETWORK
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.TimeUnit
@@ -31,9 +33,9 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             val preferences = Injekt.get<PreferencesHelper>()
             val interval = prefInterval ?: preferences.libraryUpdateInterval().get()
             if (interval > 0) {
-                val restrictions = preferences.libraryUpdateRestriction()!!
-                val acRestriction = "ac" in restrictions
-                val wifiRestriction = if ("wifi" in restrictions) {
+                val restrictions = preferences.libraryUpdateRestriction().get()
+                val acRestriction = CHARGING in restrictions
+                val wifiRestriction = if (UNMETERED_NETWORK in restrictions) {
                     NetworkType.UNMETERED
                 } else {
                     NetworkType.CONNECTED

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -1,5 +1,8 @@
 package eu.kanade.tachiyomi.data.preference
 
+const val UNMETERED_NETWORK = "wifi"
+const val CHARGING = "ac"
+
 /**
  * This class stores the values for the preferences in the application.
  */

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -227,7 +227,7 @@ class PreferencesHelper(val context: Context) {
 
     fun libraryUpdateInterval() = flowPrefs.getInt(Keys.libraryUpdateInterval, 24)
 
-    fun libraryUpdateRestriction() = prefs.getStringSet(Keys.libraryUpdateRestriction, setOf("wifi"))
+    fun libraryUpdateRestriction() = flowPrefs.getStringSet(Keys.libraryUpdateRestriction, setOf("wifi"))
 
     fun libraryUpdateCategories() = flowPrefs.getStringSet(Keys.libraryUpdateCategories, emptySet())
     fun libraryUpdateCategoriesExclude() = flowPrefs.getStringSet(Keys.libraryUpdateCategoriesExclude, emptySet())

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -227,7 +227,7 @@ class PreferencesHelper(val context: Context) {
 
     fun libraryUpdateInterval() = flowPrefs.getInt(Keys.libraryUpdateInterval, 24)
 
-    fun libraryUpdateRestriction() = flowPrefs.getStringSet(Keys.libraryUpdateRestriction, setOf("wifi"))
+    fun libraryUpdateRestriction() = flowPrefs.getStringSet(Keys.libraryUpdateRestriction, setOf(UNMETERED_NETWORK))
 
     fun libraryUpdateCategories() = flowPrefs.getStringSet(Keys.libraryUpdateCategories, emptySet())
     fun libraryUpdateCategoriesExclude() = flowPrefs.getStringSet(Keys.libraryUpdateCategoriesExclude, emptySet())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -12,7 +12,9 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
+import eu.kanade.tachiyomi.data.preference.CHARGING
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.preference.UNMETERED_NETWORK
 import eu.kanade.tachiyomi.data.preference.asImmediateFlow
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
@@ -152,9 +154,8 @@ class SettingsLibraryController : SettingsController() {
                 key = Keys.libraryUpdateRestriction
                 titleRes = R.string.pref_library_update_restriction
                 entriesRes = arrayOf(R.string.network_unmetered, R.string.charging)
-                entryValues = arrayOf("wifi", "ac")
-                summaryRes = R.string.pref_library_update_restriction_summary
-                defaultValue = setOf("wifi")
+                entryValues = arrayOf(UNMETERED_NETWORK, CHARGING)
+                defaultValue = setOf(UNMETERED_NETWORK)
 
                 preferences.libraryUpdateInterval().asImmediateFlow { isVisible = it > 0 }
                     .launchIn(viewScope)
@@ -164,6 +165,33 @@ class SettingsLibraryController : SettingsController() {
                     Handler().post { LibraryUpdateJob.setupTask(context) }
                     true
                 }
+
+                fun updateSummary() {
+                    val restrictions = preferences.libraryUpdateRestriction().get()
+                        .sorted()
+                        .map {
+                            when (it) {
+                                UNMETERED_NETWORK -> context.getString(R.string.network_unmetered)
+                                CHARGING -> context.getString(R.string.charging)
+                                else -> it
+                            }
+                        }
+                    val restrictionsText = if (restrictions.isEmpty()) {
+                        context.getString(R.string.none)
+                    } else {
+                        restrictions.joinToString()
+                    }
+
+                    summary = buildSpannedString {
+                        append(context.getString(R.string.pref_library_update_restriction_summary))
+                        appendLine()
+                        append(context.getString(R.string.restrictions, restrictionsText))
+                    }
+                }
+
+                preferences.libraryUpdateRestriction().asFlow()
+                    .onEach { updateSummary() }
+                    .launchIn(viewScope)
             }
             switchPreference {
                 key = Keys.updateOnlyNonCompleted

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -182,9 +182,7 @@ class SettingsLibraryController : SettingsController() {
                         restrictions.joinToString()
                     }
 
-                    summary = buildSpannedString {
-                        append(context.getString(R.string.restrictions, restrictionsText))
-                    }
+                    summary = context.getString(R.string.restrictions, restrictionsText)
                 }
 
                 preferences.libraryUpdateRestriction().asFlow()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -183,8 +183,6 @@ class SettingsLibraryController : SettingsController() {
                     }
 
                     summary = buildSpannedString {
-                        append(context.getString(R.string.pref_library_update_restriction_summary))
-                        appendLine()
                         append(context.getString(R.string.restrictions, restrictionsText))
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,6 +215,7 @@
     <string name="pref_library_update_restriction_summary">Update only when the conditions are met</string>
     <string name="network_unmetered">Unmetered network</string>
     <string name="charging">Charging</string>
+    <string name="restrictions">Restrictions: %s</string>
     <string name="pref_update_only_non_completed">Only update ongoing manga</string>
     <string name="pref_library_update_refresh_metadata">Automatically refresh metadata</string>
     <string name="pref_library_update_refresh_metadata_summary">Check for new cover and details when updating library</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,6 @@
     <string name="update_weekly">Weekly</string>
     <string name="pref_library_update_prioritization">Update order</string>
     <string name="pref_library_update_restriction">Update restrictions</string>
-    <string name="pref_library_update_restriction_summary">Update only when the conditions are met</string>
     <string name="network_unmetered">Unmetered network</string>
     <string name="charging">Charging</string>
     <string name="restrictions">Restrictions: %s</string>


### PR DESCRIPTION
Closes #4957

<img width="324" alt="Screenshot 2021-05-25 at 14 59 41" src="https://user-images.githubusercontent.com/2139133/119453641-3a771d80-bd6a-11eb-9011-d0fd1f14d988.png">

<img width="327" alt="Screenshot 2021-05-25 at 14 59 49" src="https://user-images.githubusercontent.com/2139133/119453655-3c40e100-bd6a-11eb-8fe7-00bb76122c18.png">

<img width="321" alt="Screenshot 2021-05-25 at 14 59 56" src="https://user-images.githubusercontent.com/2139133/119453661-3d720e00-bd6a-11eb-92a3-b14451f1ee21.png">

I also pulled the `wifi` and `ac` strings into constants.