### PR TITLE
Set grey setting sheet for Grey background option

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -445,6 +445,10 @@
 
     <!--== Dark Grey Reader ==-->
     <style name="Theme.Reader.Dark.Grey" parent="Theme.Base.Reader.Dark">
+        <!-- Theme colors -->
+        <item name="colorSurface">@color/backgroundDark</item>
+
+        <!-- Base background/text colors -->
         <item name="android:colorBackground">@color/backgroundDark</item>
     </style>
 


### PR DESCRIPTION
It feels odd enough that having Gray theme isn't respected in the in-reader settings sheet. I get that it follows the background set to the manga but this isn't true for the Gray background option. I can't fix so it all follows theme unfortunatelt but I can fix this.

| Full Grey (new) | Grey and AMOLED (old) |
| ---------------- | --------------------------- |
| ![new](https://user-images.githubusercontent.com/10836780/119533482-2b05cd80-bd86-11eb-924c-22b1f53b5a40.png) | ![old](https://user-images.githubusercontent.com/10836780/119533817-8a63dd80-bd86-11eb-9e7d-c361a5e3d1f4.png) |
