### PR TITLE
Added ability to hide "Local" tag from library manga.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -183,6 +183,8 @@ object PreferenceKeys {
 
     const val unreadBadge = "display_unread_badge"
 
+    const val localBadge = "display_local_badge"
+
     const val categoryTabs = "display_category_tabs"
 
     const val categoryNumberOfItems = "display_number_of_items"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -226,6 +226,8 @@ class PreferencesHelper(val context: Context) {
 
     fun downloadBadge() = flowPrefs.getBoolean(Keys.downloadBadge, false)
 
+    fun localBadge() = flowPrefs.getBoolean(Keys.localBadge, true)
+
     fun downloadedOnly() = flowPrefs.getBoolean(Keys.downloadedOnly, false)
 
     fun unreadBadge() = flowPrefs.getBoolean(Keys.unreadBadge, true)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryComfortableGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryComfortableGridHolder.kt
@@ -51,7 +51,7 @@ class LibraryComfortableGridHolder(
             text = item.downloadCount.toString()
         }
         // set local visibility if its local manga
-        binding.localText.isVisible = item.manga.isLocal()
+        binding.localText.isVisible = item.isLocal
 
         // For rounded corners
         binding.card.clipToOutline = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCompactGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCompactGridHolder.kt
@@ -49,7 +49,7 @@ open class LibraryCompactGridHolder(
             text = item.downloadCount.toString()
         }
         // set local visibility if its local manga
-        binding.localText.isVisible = item.manga.isLocal()
+        binding.localText.isVisible = item.isLocal
 
         // For rounded corners
         binding.card.clipToOutline = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -28,6 +28,7 @@ class LibraryItem(val manga: LibraryManga, private val libraryDisplayMode: Prefe
 
     var downloadCount = -1
     var unreadCount = -1
+    var isLocal = false
 
     override fun getLayoutRes(): Int {
         return when (libraryDisplayMode.get()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryListHolder.kt
@@ -53,7 +53,7 @@ class LibraryListHolder(
             text = "${item.downloadCount}"
         }
         // show local text badge if local manga
-        binding.localText.isVisible = item.manga.isLocal()
+        binding.localText.isVisible = item.isLocal
 
         // Create thumbnail onclick to simulate long click
         binding.thumbnail.setOnClickListener {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -195,6 +195,7 @@ class LibraryPresenter(
     private fun setBadges(map: LibraryMap) {
         val showDownloadBadges = preferences.downloadBadge().get()
         val showUnreadBadges = preferences.unreadBadge().get()
+        val showLocalBadges = preferences.localBadge().get()
 
         for ((_, itemList) in map) {
             for (item in itemList) {
@@ -210,6 +211,13 @@ class LibraryPresenter(
                 } else {
                     // Unset unread count if not enabled
                     -1
+                }
+
+                item.isLocal = if (showLocalBadges) {
+                    item.manga.isLocal()
+                } else {
+                    // Hide / Unset local badge if not enabled
+                    false
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsSheet.kt
@@ -276,14 +276,16 @@ class LibrarySettingsSheet(
         inner class BadgeGroup : Group {
             private val downloadBadge = Item.CheckboxGroup(R.string.action_display_download_badge, this)
             private val unreadBadge = Item.CheckboxGroup(R.string.action_display_unread_badge, this)
+            private val localBadge = Item.CheckboxGroup(R.string.action_display_local_badge, this)
 
             override val header = Item.Header(R.string.badges_header)
-            override val items = listOf(downloadBadge, unreadBadge)
+            override val items = listOf(downloadBadge, unreadBadge, localBadge)
             override val footer = null
 
             override fun initModels() {
                 downloadBadge.checked = preferences.downloadBadge().get()
                 unreadBadge.checked = preferences.unreadBadge().get()
+                localBadge.checked = preferences.localBadge().get()
             }
 
             override fun onItemClicked(item: Item) {
@@ -292,6 +294,7 @@ class LibrarySettingsSheet(
                 when (item) {
                     downloadBadge -> preferences.downloadBadge().set((item.checked))
                     unreadBadge -> preferences.unreadBadge().set((item.checked))
+                    localBadge -> preferences.localBadge().set((item.checked))
                 }
                 adapter.notifyItemChanged(item)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="action_display_comfortable_grid">Comfortable grid</string>
     <string name="action_display_download_badge">Download badges</string>
     <string name="action_display_unread_badge">Unread badges</string>
+    <string name="action_display_local_badge">Local badges</string>
     <string name="action_display_show_tabs">Show category tabs</string>
     <string name="action_display_show_number_of_items">Show number of items</string>
     <string name="action_disable">Disable</string>


### PR DESCRIPTION
This PR adds a checkbox to the Library settings sheet underneath the "Unread" and "Download" badge display options to allow hiding the green "Local" tag on library manga.

This PR closes #5018 