### PR TITLE
Adjust chapter download button visual

### DIFF
--- a/app/src/main/res/layout/chapter_download_view.xml
+++ b/app/src/main/res/layout/chapter_download_view.xml
@@ -8,6 +8,22 @@
     android:padding="8dp">
 
     <ImageView
+        android:id="@+id/download_status_icon"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitXY"
+        tools:ignore="ContentDescription" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/download_progress"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="2dp"
+        android:progress="100"
+        app:indicatorInset="0dp"
+        app:indicatorSize="22dp" />
+
+    <ImageView
         android:id="@+id/download_icon"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -15,24 +31,6 @@
         android:scaleType="fitXY"
         app:srcCompat="@drawable/ic_arrow_downward_24dp"
         app:tint="?android:attr/textColorHint"
-        tools:ignore="ContentDescription" />
-
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:id="@+id/download_progress"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="1dp"
-        android:progress="100"
-        app:indicatorColor="?android:attr/textColorHint"
-        app:indicatorInset="0dp"
-        app:indicatorSize="24dp"
-        app:trackThickness="2dp" />
-
-    <ImageView
-        android:id="@+id/download_status_icon"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="fitXY"
         tools:ignore="ContentDescription" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/chapters_item.xml
+++ b/app/src/main/res/layout/chapters_item.xml
@@ -6,7 +6,7 @@
     android:layout_height="?android:attr/listPreferredItemHeight"
     android:background="@drawable/list_item_selector_background"
     android:paddingStart="16dp"
-    android:paddingEnd="4dp">
+    android:paddingEnd="5dp">
 
     <ImageView
         android:id="@+id/bookmark_icon"


### PR DESCRIPTION
* Remove the blinking icon and add back the indeterminate indicator for queued items
* Make the downloading indicator a solid circle

[Preview](https://user-images.githubusercontent.com/12537387/119855198-e885f180-bf3b-11eb-8688-49971fad477d.mp4)

