### PR TITLE
Add better library item selectors

### DIFF
--- a/app/src/main/res/drawable/library_item_selector.xml
+++ b/app/src/main/res/drawable/library_item_selector.xml
@@ -3,16 +3,39 @@
     android:color="?attr/colorLibrarySelection">
     <item>
         <selector>
-            <item android:state_selected="true">
-                <color android:color="?attr/colorLibrarySelectionActive" />
+            <item
+                android:state_selected="true"
+                android:top="2dp"
+                android:right="2dp"
+                android:bottom="2dp"
+                android:left="2dp">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/card_radius" />
+                    <solid android:color="?attr/colorLibrarySelectionActive" />
+                </shape>
             </item>
 
-            <item android:state_activated="true">
-                <color android:color="?attr/colorLibrarySelectionActive" />
+            <item
+                android:state_activated="true"
+                android:top="2dp"
+                android:right="2dp"
+                android:bottom="2dp"
+                android:left="2dp">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/card_radius" />
+                    <solid android:color="?attr/colorLibrarySelectionActive" />
+                </shape>
             </item>
 
-            <item>
-                <color android:color="?android:attr/colorBackground" />
+            <item
+                android:top="2dp"
+                android:right="2dp"
+                android:bottom="2dp"
+                android:left="2dp">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/card_radius" />
+                    <solid android:color="?android:attr/colorBackground" />
+                </shape>
             </item>
         </selector>
     </item>

--- a/app/src/main/res/layout/source_comfortable_grid_item.xml
+++ b/app/src/main/res/layout/source_comfortable_grid_item.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_margin="2dp"
     android:background="@drawable/library_item_selector"
     android:padding="4dp">
 

--- a/app/src/main/res/layout/source_compact_grid_item.xml
+++ b/app/src/main/res/layout/source_compact_grid_item.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_margin="2dp"
     android:background="@drawable/library_item_selector"
     android:padding="4dp">
 


### PR DESCRIPTION
Inspired by the TachiyomiJ2K and Takoyomi (?) method of library item selection.

## Tested
- **Android 10** emulator with **Pixel 3 XL** preset.
- **Android 10** with **Huawei Mate 20 Pro**.
- All base themes.
- Portrait and landscape.
- `1`, `2`, `3` and `7` items per row.

## Comparisons
**Note:** Notification bar being black is not related to any files changed in the PR.

| Compact (New) | Compact (Old) |
| ----- | ---- |
| ![new-compact](https://user-images.githubusercontent.com/10836780/120117010-5bd17280-c18b-11eb-8e91-923017e427dc.png) | ![old-compact](https://user-images.githubusercontent.com/10836780/120117012-60962680-c18b-11eb-84e3-2500e6b203db.png) |

| Comfortable (New) | Comfortable (Old) |
| ----- | ---- |
| ![new-comfort](https://user-images.githubusercontent.com/10836780/120117023-67bd3480-c18b-11eb-9e47-2bed752d88df.png) | ![old-comfort](https://user-images.githubusercontent.com/10836780/120117030-6c81e880-c18b-11eb-922d-c826c3bd59ee.png) |

