### PR TITLE
Add long click to view manga in Migration Source Search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchController.kt
@@ -33,6 +33,11 @@ class SourceSearchController(
         dialog.showDialog(router)
         return true
     }
+
+    override fun onItemLongClick(position: Int) {
+        view?.let { super.onItemClick(it, position) }
+    }
+
     private companion object {
         const val MANGA_KEY = "oldManga"
     }


### PR DESCRIPTION
apparently was added to Sy in https://github.com/jobobby04/TachiyomiSY/commit/8686fecb1fe0f436e503f005de3e6218fe8f76d5
added it for main as well

Co-Authored-By: jobobby04 <jobobby04@users.noreply.github.com>

fixes https://github.com/tachiyomiorg/tachiyomi/issues/5027