### PR TITLE
Added warning when uninstalling extension with library manga dependencies

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension
 import android.content.Context
 import android.graphics.drawable.Drawable
 import com.jakewharton.rxrelay.BehaviorRelay
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.plusAssign
 import eu.kanade.tachiyomi.extension.api.ExtensionGithubApi
@@ -40,6 +41,8 @@ class ExtensionManager(
      * API where all the available extensions can be found.
      */
     private val api = ExtensionGithubApi()
+
+    private val db by lazy { Injekt.get<DatabaseHelper>() }
 
     /**
      * The installer which installs, updates and uninstalls the extensions.
@@ -165,6 +168,16 @@ class ExtensionManager(
             }
 
             availableExtensions = extensions
+        }
+    }
+
+    fun findSourcesDependentOnExtension(pkgName: String): List<Source> {
+        val allLibraryManga = db.getLibraryMangas().executeAsBlocking()
+
+        val extension = installedExtensions.first { it.pkgName == pkgName }
+
+        return extension.sources.filter { source ->
+            allLibraryManga.any { libraryManga -> libraryManga.source == source.id }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseController.kt
@@ -30,16 +30,16 @@ class BrowseController :
     RootController,
     TabbedController {
 
-    constructor(toExtensions: Boolean = false) : super(
-        bundleOf(TO_EXTENSIONS_EXTRA to toExtensions)
+    constructor(selectedTab: Int = SOURCES_CONTROLLER) : super(
+        bundleOf(SELECTED_TAB_EXTRA to selectedTab)
     )
 
     @Suppress("unused")
-    constructor(bundle: Bundle) : this(bundle.getBoolean(TO_EXTENSIONS_EXTRA))
+    constructor(bundle: Bundle) : this(bundle.getInt(SELECTED_TAB_EXTRA))
 
     private val preferences: PreferencesHelper by injectLazy()
 
-    private val toExtensions = args.getBoolean(TO_EXTENSIONS_EXTRA, false)
+    private val selectedTab = args.getInt(SELECTED_TAB_EXTRA, SOURCES_CONTROLLER)
 
     val extensionListUpdateRelay: PublishRelay<Boolean> = PublishRelay.create()
 
@@ -57,9 +57,7 @@ class BrowseController :
         adapter = BrowseAdapter()
         binding.pager.adapter = adapter
 
-        if (toExtensions) {
-            binding.pager.currentItem = EXTENSIONS_CONTROLLER
-        }
+        binding.pager.currentItem = selectedTab
     }
 
     override fun onDestroyView(view: View) {
@@ -72,7 +70,6 @@ class BrowseController :
         if (type.isEnter) {
             (activity as? MainActivity)?.binding?.tabs?.apply {
                 setupWithViewPager(binding.pager)
-
                 // Show badge on tab for extension updates
                 setExtensionUpdateBadge()
             }
@@ -101,6 +98,10 @@ class BrowseController :
                 getTabAt(EXTENSIONS_CONTROLLER)?.removeBadge()
             }
         }
+    }
+
+    fun setActiveTab(tab: Int) {
+        binding.pager.currentItem = tab
     }
 
     private inner class BrowseAdapter : RouterPagerAdapter(this@BrowseController) {
@@ -134,7 +135,7 @@ class BrowseController :
     }
 
     companion object {
-        const val TO_EXTENSIONS_EXTRA = "to_extensions"
+        const val SELECTED_TAB_EXTRA = "selected_tab"
 
         const val SOURCES_CONTROLLER = 0
         const val EXTENSIONS_CONTROLLER = 1

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionPresenter.kt
@@ -146,6 +146,8 @@ open class ExtensionPresenter(
         extensionManager.uninstallExtension(pkgName)
     }
 
+    fun findSourcesDependentOnExtension(pkgName: String) = extensionManager.findSourcesDependentOnExtension(pkgName)
+
     fun findAvailableExtensions() {
         extensionManager.findAvailableExtensions()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionUninstallWarnDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionUninstallWarnDialog.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.ui.browse.extension
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import com.afollestad.materialdialogs.MaterialDialog
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.SourceManager
+import eu.kanade.tachiyomi.ui.base.controller.DialogController
+import eu.kanade.tachiyomi.util.system.LocaleHelper
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class ExtensionUninstallWarnDialog : DialogController {
+
+    val sourceManager: SourceManager = Injekt.get()
+
+    val sources: List<Source>
+
+    constructor(dependentSources: List<Source>) : super(
+        bundleOf(
+            KEY_SOURCE_IDS to dependentSources.map { it.id }.toTypedArray()
+        )
+    ) {
+
+        sources = dependentSources
+    }
+
+    /**
+     * Restore dialog.
+     * @param bundle bundle containing data from state restore.
+     */
+    @Suppress("unused")
+    constructor(bundle: Bundle) : super(bundle) {
+        // Get list of source IDs from bundle
+        val sourceIDs = bundle.getLongArray(KEY_SOURCE_IDS)
+
+        sources = sourceIDs?.map { id ->
+            sourceManager.get(id)
+        }?.filterNotNull()?.toList() ?: emptyList()
+    }
+
+    override fun onCreateDialog(savedViewState: Bundle?): Dialog {
+        val diagMessage = activity!!.applicationContext.getString(R.string.ext_uninstall_warning_message, sources.joinToString("\n") { "- ${it.name} (${LocaleHelper.getDisplayName(it.lang)})" })
+        return MaterialDialog(activity!!).show {
+            message(text = diagMessage)
+
+            @Suppress("DEPRECATION")
+            neutralButton(R.string.ext_uninstall) { uninstallCallback() }
+            negativeButton(android.R.string.cancel)
+            positiveButton(R.string.migrate) { migrationCallback() }
+        }
+    }
+
+    var migrationCallback: () -> Unit = {}
+
+    var uninstallCallback: () -> Unit = {}
+
+    private companion object {
+        const val KEY_SOURCE_IDS = "ExtensionUninstallWarnDialog.array.int.sourceids"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsHeaderAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsHeaderAdapter.kt
@@ -42,7 +42,7 @@ class ExtensionDetailsHeaderAdapter(private val presenter: ExtensionDetailsPrese
             binding.extensionPkg.text = extension.pkgName
 
             binding.extensionUninstallButton.clicks()
-                .onEach { presenter.uninstallExtension() }
+                .onEach { checkExtensionDependencies(extension.pkgName) }
                 .launchIn(presenter.presenterScope)
 
             if (extension.isObsolete) {
@@ -53,6 +53,16 @@ class ExtensionDetailsHeaderAdapter(private val presenter: ExtensionDetailsPrese
             if (extension.isUnofficial) {
                 binding.extensionWarningBanner.isVisible = true
                 binding.extensionWarningBanner.setText(R.string.unofficial_extension_message)
+            }
+        }
+
+        private fun checkExtensionDependencies(pkgName: String) {
+            val sourceDependencies = presenter.findSourcesDependentOnExtension(pkgName)
+
+            if (sourceDependencies.isEmpty()) {
+                presenter.uninstallExtension()
+            } else {
+                presenter.showExtensionWarnDialog(sourceDependencies)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -301,7 +301,7 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
                     router.popToRoot()
                 }
                 setSelectedNavItem(R.id.nav_browse)
-                router.pushController(BrowseController(true).withFadeTransaction())
+                router.pushController(BrowseController(BrowseController.EXTENSIONS_CONTROLLER).withFadeTransaction())
             }
             SHORTCUT_MANGA -> {
                 val extras = intent.extras ?: return false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <string name="untrusted_extension_message">This extension was signed with an untrusted certificate and wasn\'t activated.\n\nA malicious extension could read any login credentials stored in Tachiyomi or execute arbitrary code.\n\nBy trusting this certificate you accept these risks.</string>
     <string name="obsolete_extension_message">This extension is no longer available.</string>
     <string name="unofficial_extension_message">This extension is not from the official Tachiyomi extensions list.</string>
+    <string name="ext_uninstall_warning_message">One or more manga in your library depend on sources provided by this extension. If you uninstall this extension, you will not be able to read or receive updates for those manga. Migrate those manga to continue to read them and receive updates\n\nSource Dependencies:\n%1$s</string>
     <string name="ext_version_info">Version: %1$s</string>
     <string name="ext_language_info">Language: %1$s</string>
     <string name="ext_nsfw_short">18+</string>


### PR DESCRIPTION
This PR adds the feature to Tachiyomi in that if a user attempts to uninstall an extension that has sources used by their library manga, a dialog will appear warning the user about it, and indicating what sources are depended on, as well as giving the option to migrate it.

The dialog has 3 options:
- "Uninstall": Continue with extension uninstalling: Android will prompt for uninstalling the extension
- "Cancel": Self-explanatory
- "Migrate": Begins the migration process for the extension:
   - If there is only 1 source dependency, Tachiyomi will open the source migration page (as if the user clicked on a source under the Migration tab)
   - If there is more than 1 source dependency, Tachiyomi will go to the Migration tab
   

This PR closes #3787

### Other Changes
In order to allow the dialog to open the migration tab directly, the BrowseController has been modified to work with the index of what tab should be selected, instead of a boolean specifying that the Extension tab should be selected.