### PR TITLE
Added chapter-contextual disabling / hiding of reader prev/next buttons

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -88,6 +88,9 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
         }
+
+        private const val ENABLED_BUTTON_IMAGE_ALPHA = 255
+        private const val DISABLED_BUTTON_IMAGE_ALPHA = 64
     }
 
     private val preferences: PreferencesHelper by injectLazy()
@@ -589,12 +592,27 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
 
     /**
      * Called from the presenter whenever a new [viewerChapters] have been set. It delegates the
-     * method to the current viewer, but also set the subtitle on the toolbar.
+     * method to the current viewer, but also set the subtitle on the toolbar, and
+     * hides or disables the reader prev/next buttons if there's a prev or next chapter
      */
     fun setChapters(viewerChapters: ViewerChapters) {
         binding.pleaseWait.isVisible = false
         viewer?.setChapters(viewerChapters)
         binding.toolbar.subtitle = viewerChapters.currChapter.chapter.name
+
+        val leftChapterObject = if (viewer is R2LPagerViewer) viewerChapters.nextChapter else viewerChapters.prevChapter
+        val rightChapterObject = if (viewer is R2LPagerViewer) viewerChapters.prevChapter else viewerChapters.nextChapter
+
+        if (leftChapterObject == null && rightChapterObject == null) {
+            binding.leftChapter.isVisible = false
+            binding.rightChapter.isVisible = false
+        } else {
+            binding.leftChapter.isEnabled = leftChapterObject != null
+            binding.leftChapter.imageAlpha = if (leftChapterObject != null) ENABLED_BUTTON_IMAGE_ALPHA else DISABLED_BUTTON_IMAGE_ALPHA
+
+            binding.rightChapter.isEnabled = rightChapterObject != null
+            binding.rightChapter.imageAlpha = if (rightChapterObject != null) ENABLED_BUTTON_IMAGE_ALPHA else DISABLED_BUTTON_IMAGE_ALPHA
+        }
 
         // Invalidate menu to show proper chapter bookmark state
         invalidateOptionsMenu()


### PR DESCRIPTION
This closes #5288 by disabling and setting the opacity of the arrow image on the prev / next chapter buttons in the Reader to 1/4 opacity (to dim it) if there is no next or previous chapter respectively.

### Additional feature for single chapter manga
For manga that have a single chapter, I included the feature that both the "previous" and "next" chapter buttons will be hidden, which has the beneficial side-effect of allowing the page seek-bar to expand to take up the space.

I included this feature as I believe it would be an additional improvement to the reader (and it is implemented in the same Tachiyomi function), however if it is preferred, I could move that feature to a different PR or just nix it entirely.

## Edit: Previews
Disabling next chapter button if no chapter:
![disabled_reader_btn](https://user-images.githubusercontent.com/25621728/120836335-b1f33c80-c522-11eb-9de9-571b1f75a563.png)


Hiding both previous and next chapter buttons for single chapter manga:
![single_chapter_nav](https://user-images.githubusercontent.com/25621728/120836448-d18a6500-c522-11eb-9759-2f6fe579ffa5.png)


