### PR TITLE
Fix Download Queue opening multiple times from rapidly clicking Updates (#5249)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -168,7 +168,9 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
                         controller?.showSettingsSheet()
                     }
                     R.id.nav_updates -> {
-                        router.pushController(DownloadController().withFadeTransaction())
+                        if (router.backstackSize == 1) {
+                            router.pushController(DownloadController().withFadeTransaction())
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #5249 by adding a check that the backstack size is 1 before opening the Download Queue