### PR TITLE
Add ripple to history items

### DIFF
--- a/app/src/main/res/layout/history_item.xml
+++ b/app/src/main/res/layout/history_item.xml
@@ -4,11 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/holder"
     android:layout_width="match_parent"
-    android:layout_height="80dp"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="8dp"
-    android:layout_marginEnd="8dp"
-    android:layout_marginBottom="8dp"
+    android:layout_height="96dp"
+    android:paddingStart="16dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="8dp"
+    android:paddingBottom="8dp"
+    android:background="@drawable/selectable_item_background"
     android:orientation="horizontal">
 
     <ImageView


### PR DESCRIPTION
It felt unnatural tapping a history item and it not giving any kind of feedback of being pressed.

- Replaces `margin` with `padding`.
- Adds the `selectableItemBackground` tweaked ripple drawable.
- Changes `height` to match the `padding` so the layout remains exactly the same.

| New (tap/hold) | Old (tap/hold) |
| ----- | ---- |
| ![New](https://user-images.githubusercontent.com/10836780/121094798-7b9e1180-c7ef-11eb-8118-613a78717528.png) | ![Old](https://user-images.githubusercontent.com/10836780/121094809-7f319880-c7ef-11eb-912d-b6da40c52e24.png) |
