### PR TITLE
Added text to category changing dialog when shown with no categories

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
@@ -9,6 +9,8 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
+import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
+import eu.kanade.tachiyomi.ui.category.CategoryController
 
 class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
     DialogController(bundle) where T : Controller, T : ChangeMangaCategoriesDialog.Listener {
@@ -32,7 +34,8 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
     override fun onCreateDialog(savedViewState: Bundle?): Dialog {
         return MaterialDialog(activity!!)
             .title(R.string.action_move_category)
-            .positiveButton(android.R.string.ok)
+            .negativeButton(android.R.string.cancel)
+
             .apply {
                 if (categories.isNotEmpty()) {
                     listItemsMultiChoice(
@@ -43,9 +46,22 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
                         val newCategories = selections.map { categories[it] }
                         (targetController as? Listener)?.updateCategoriesForMangas(mangas, newCategories)
                     }
-                        .negativeButton(android.R.string.cancel)
+                        .positiveButton(android.R.string.ok)
                 } else {
                     message(R.string.information_empty_category_dialog)
+                        .positiveButton(R.string.action_edit_categories) {
+                            /*
+                            If the selection isn't cleared and actionmode not invalidated,
+                            the top toolbar stays in action mode, (with the # of selected items,
+                            and select all / inverse buttons)
+                             */
+                            if (targetController is LibraryController) {
+                                val libController = targetController as LibraryController
+                                libController.clearSelection()
+                            }
+                            router.popCurrentController()
+                            router.pushController(CategoryController().withFadeTransaction())
+                        }
                 }
             }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
@@ -32,16 +32,22 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
     override fun onCreateDialog(savedViewState: Bundle?): Dialog {
         return MaterialDialog(activity!!)
             .title(R.string.action_move_category)
-            .listItemsMultiChoice(
-                items = categories.map { it.name },
-                initialSelection = preselected.toIntArray(),
-                allowEmptySelection = true
-            ) { _, selections, _ ->
-                val newCategories = selections.map { categories[it] }
-                (targetController as? Listener)?.updateCategoriesForMangas(mangas, newCategories)
-            }
             .positiveButton(android.R.string.ok)
-            .negativeButton(android.R.string.cancel)
+            .apply {
+                if (categories.isNotEmpty()) {
+                    listItemsMultiChoice(
+                        items = categories.map { it.name },
+                        initialSelection = preselected.toIntArray(),
+                        allowEmptySelection = true
+                    ) { _, selections, _ ->
+                        val newCategories = selections.map { categories[it] }
+                        (targetController as? Listener)?.updateCategoriesForMangas(mangas, newCategories)
+                    }
+                        .negativeButton(android.R.string.cancel)
+                } else {
+                    message(R.string.information_empty_category_dialog)
+                }
+            }
     }
 
     interface Listener {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ChangeMangaCategoriesDialog.kt
@@ -35,7 +35,6 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
         return MaterialDialog(activity!!)
             .title(R.string.action_move_category)
             .negativeButton(android.R.string.cancel)
-
             .apply {
                 if (categories.isNotEmpty()) {
                     listItemsMultiChoice(
@@ -50,11 +49,6 @@ class ChangeMangaCategoriesDialog<T>(bundle: Bundle? = null) :
                 } else {
                     message(R.string.information_empty_category_dialog)
                         .positiveButton(R.string.action_edit_categories) {
-                            /*
-                            If the selection isn't cleared and actionmode not invalidated,
-                            the top toolbar stays in action mode, (with the # of selected items,
-                            and select all / inverse buttons)
-                             */
                             if (targetController is LibraryController) {
                                 val libController = targetController as LibraryController
                                 libController.clearSelection()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -482,12 +482,6 @@ class LibraryController(
         actionMode = null
     }
 
-    fun clearSelection() {
-        selectedMangas.clear()
-        selectionRelay.call(LibrarySelectionEvent.Cleared())
-        actionMode!!.invalidate()
-    }
-
     fun openManga(manga: Manga) {
         // Notify the presenter a manga is being opened.
         presenter.onOpenManga()
@@ -524,6 +518,16 @@ class LibraryController(
         } else if (selectedMangas.remove(manga)) {
             selectionRelay.call(LibrarySelectionEvent.Unselected(manga))
         }
+    }
+
+    /**
+     * Clear all of the manga currently selected, and
+     * invalidate the action mode to revert the top toolbar
+     */
+    fun clearSelection() {
+        selectedMangas.clear()
+        selectionRelay.call(LibrarySelectionEvent.Cleared())
+        invalidateActionMode()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -482,6 +482,12 @@ class LibraryController(
         actionMode = null
     }
 
+    fun clearSelection() {
+        selectedMangas.clear()
+        selectionRelay.call(LibrarySelectionEvent.Cleared())
+        actionMode!!.invalidate()
+    }
+
     fun openManga(manga: Manga) {
         // Notify the presenter a manga is being opened.
         presenter.onOpenManga()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,6 +719,7 @@
     <string name="information_no_recent_manga">Nothing read recently</string>
     <string name="information_empty_library">Your library is empty. Add series to your library from Browse.</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>
+    <string name="information_empty_category_dialog">You have no categories. Go to \"More\" > \"Categories\" to create them</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <!-- Do not translate "WebView" -->
     <string name="information_webview_required">WebView is required for Tachiyomi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,7 +719,7 @@
     <string name="information_no_recent_manga">Nothing read recently</string>
     <string name="information_empty_library">Your library is empty. Add series to your library from Browse.</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>
-    <string name="information_empty_category_dialog">You have no categories. Go to \"More\" > \"Categories\" to create them</string>
+    <string name="information_empty_category_dialog">You don\'t have any categories yet.</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <!-- Do not translate "WebView" -->
     <string name="information_webview_required">WebView is required for Tachiyomi</string>


### PR DESCRIPTION
Currently (as of 0.11.1), if a user long clicks manga in their library, and hits the category button on the action bar, but they don't have any categories setup: they will be met with a "Set Categories" dialog that has no content, a cancel button, and an OK button. I'm certain this could be a source of confusion for new users

This PR modifies the ChangeMangaCategoriesDialog to present the user with the text: 

> You have no categories. Go to \"More\" > \"Categories\" to create them

and only an OK button if the dialog is invoked with an empty category list. (As far as I can tell, the Library is the only place where this dialog can be invoked with an empty category list)