### PR TITLE
Fix library settings sheet causing app to crash when the category list is empty

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -262,8 +262,12 @@ class LibraryController(
     }
 
     fun showSettingsSheet() {
-        adapter?.categories?.get(binding.libraryPager.currentItem)?.let { category ->
-            settingsSheet?.show(category)
+        if (adapter?.categories?.isNotEmpty() == true) {
+            adapter?.categories?.get(binding.libraryPager.currentItem)?.let { category ->
+                settingsSheet?.show(category)
+            }
+        } else {
+            settingsSheet?.show()
         }
     }
 


### PR DESCRIPTION
get() throws an error on an emptyList. this checks if the category list is empty and uses the normal settingsSheet?.show() method if it is.