### PR TITLE
Improvements to the new library item selectors

### DIFF
--- a/app/src/main/res/color/selector_overlay.xml
+++ b/app/src/main/res/color/selector_overlay.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.2" android:color="?attr/colorAccent" />
+</selector>

--- a/app/src/main/res/drawable/library_item_selector.xml
+++ b/app/src/main/res/drawable/library_item_selector.xml
@@ -10,7 +10,7 @@
                 android:bottom="2dp"
                 android:left="2dp">
                 <shape android:shape="rectangle">
-                    <corners android:radius="@dimen/card_radius" />
+                    <corners android:radius="@dimen/card_selector_radius" />
                     <solid android:color="?attr/colorLibrarySelectionActive" />
                 </shape>
             </item>
@@ -22,7 +22,7 @@
                 android:bottom="2dp"
                 android:left="2dp">
                 <shape android:shape="rectangle">
-                    <corners android:radius="@dimen/card_radius" />
+                    <corners android:radius="@dimen/card_selector_radius" />
                     <solid android:color="?attr/colorLibrarySelectionActive" />
                 </shape>
             </item>
@@ -33,7 +33,7 @@
                 android:bottom="2dp"
                 android:left="2dp">
                 <shape android:shape="rectangle">
-                    <corners android:radius="@dimen/card_radius" />
+                    <corners android:radius="@dimen/card_selector_radius" />
                     <solid android:color="?android:attr/colorBackground" />
                 </shape>
             </item>

--- a/app/src/main/res/drawable/library_item_selector_overlay.xml
+++ b/app/src/main/res/drawable/library_item_selector_overlay.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorLibrarySelection">
+    <item>
+        <selector xmlns:android="http://schemas.android.com/apk/res/android">
+            <item android:state_selected="true">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/card_selector_radius" />
+                    <solid android:color="@color/selector_overlay" />
+                </shape>
+            </item>
+
+            <item android:state_activated="true">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/card_selector_radius" />
+                    <solid android:color="@color/selector_overlay" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/source_comfortable_grid_item.xml
+++ b/app/src/main/res/layout/source_comfortable_grid_item.xml
@@ -6,6 +6,7 @@
     android:layout_height="wrap_content"
     android:layout_margin="2dp"
     android:background="@drawable/library_item_selector"
+    android:foreground="@drawable/library_item_selector_overlay"
     android:padding="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/source_compact_grid_item.xml
+++ b/app/src/main/res/layout/source_compact_grid_item.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content"
     android:layout_margin="2dp"
     android:background="@drawable/library_item_selector"
+    android:foreground="@drawable/library_item_selector_overlay"
     android:padding="4dp">
 
     <FrameLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
 
     <dimen name="space_between_cards">4dp</dimen>
     <dimen name="card_radius">4dp</dimen>
+    <dimen name="card_selector_radius">6dp</dimen>
     <dimen name="dialog_radius">8dp</dimen>
 
     <dimen name="fab_size">56dp</dimen>


### PR DESCRIPTION
Adding a colored overlay as suggested to me by @CarlosEsco.

This also fixes the selector corner radius so it looks even, guided by [this article](https://webdesign.tutsplus.com/tutorials/quick-tip-rounded-corners-done-right--webdesign-7127) sent by @vengiare.

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- **Android 10** with **Huawei Mate 20 Pro**.
- All themes except legacy blue (follows base blue).
- Portrait and landscape.
- `3`, and `6` items per row.

## Demo
https://user-images.githubusercontent.com/10836780/121623119-6fc08280-ca6f-11eb-99d4-ecfc281cc1d6.mp4

## Comparisons

| New | Old |
| ----- | ---- |
| ![New](https://user-images.githubusercontent.com/10836780/121623464-068d3f00-ca70-11eb-9195-50ada0df5c66.png) | ![Old](https://user-images.githubusercontent.com/10836780/121623470-09882f80-ca70-11eb-80d1-3d3e061fe2d9.png) |

