### PR TITLE
Extend library search by adding -<source> option

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -120,16 +120,16 @@ class LibraryItem(
 
     private fun containsSourceOrGenre(tag: String, sourceName: String, genres: List<String>?): Boolean {
         return if (tag.startsWith("-")) {
-            if (sourceName.contains(tag.substringAfter("-"), true)) {
-                false
-            } else {
+            if (!sourceName.contains(tag.substringAfter("-"), true)) {
                 containsGenre(tag, genres)
+            } else {
+                false
             }
         } else {
-            if (sourceName.contains(tag, true)) {
-                true
-            } else {
+            if (!sourceName.contains(tag, true)) {
                 containsGenre(tag, genres)
+            } else {
+                true
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -105,16 +105,33 @@ class LibraryItem(
      * @return true if the manga should be included, false otherwise.
      */
     override fun filter(constraint: String): Boolean {
+        val sourceName by lazy { sourceManager.getOrStub(manga.source).name }
+        val genres by lazy { manga.getGenres() }
         return manga.title.contains(constraint, true) ||
             (manga.author?.contains(constraint, true) ?: false) ||
             (manga.artist?.contains(constraint, true) ?: false) ||
             (manga.description?.contains(constraint, true) ?: false) ||
-            sourceManager.getOrStub(manga.source).name.contains(constraint, true) ||
             if (constraint.contains(",")) {
-                constraint.split(",").all { containsGenre(it.trim(), manga.getGenres()) }
+                constraint.split(",").all { containsSourceOrGenre(it.trim(), sourceName, genres) }
             } else {
-                containsGenre(constraint, manga.getGenres())
+                containsSourceOrGenre(constraint, sourceName, genres)
             }
+    }
+
+    private fun containsSourceOrGenre(tag: String, sourceName: String, genres: List<String>?): Boolean {
+        return if (tag.startsWith("-")) {
+            if (sourceName.contains(tag.substringAfter("-"), true)) {
+                false
+            } else {
+                containsGenre(tag, genres)
+            }
+        } else {
+            if (sourceName.contains(tag, true)) {
+                true
+            } else {
+                containsGenre(tag, genres)
+            }
+        }
     }
 
     private fun containsGenre(tag: String, genres: List<String>?): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -130,10 +130,9 @@ class LibraryItem(
     private fun containsSourceOrGenre(query: String, sourceName: String, genres: List<String>?): Boolean {
         val minus = query.startsWith("-")
         val tag = if (minus) { query.substringAfter("-") } else query
-        val containsGenre by lazy { containsGenre(query, genres) }
         return when (sourceName.contains(tag, true)) {
-            false -> containsGenre
-            else -> !minus
+            false -> containsGenre(query, genres)
+            else  -> !minus
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -118,6 +118,15 @@ class LibraryItem(
             }
     }
 
+    /**
+     * Filters a manga by checking whether the query is the manga's source OR part of
+     * the genres of the manga
+     * Checking for genre is done only if the query isn't part of the source name.
+     *
+     * @param query the query to check
+     * @param sourceName name of the manga's source
+     * @param genres list containing manga's genres
+     */
     private fun containsSourceOrGenre(query: String, sourceName: String, genres: List<String>?): Boolean {
         val minus = query.startsWith("-")
         val tag = if (minus) { query.substringAfter("-") } else query

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -118,19 +118,13 @@ class LibraryItem(
             }
     }
 
-    private fun containsSourceOrGenre(tag: String, sourceName: String, genres: List<String>?): Boolean {
-        return if (tag.startsWith("-")) {
-            if (!sourceName.contains(tag.substringAfter("-"), true)) {
-                containsGenre(tag, genres)
-            } else {
-                false
-            }
-        } else {
-            if (!sourceName.contains(tag, true)) {
-                containsGenre(tag, genres)
-            } else {
-                true
-            }
+    private fun containsSourceOrGenre(query: String, sourceName: String, genres: List<String>?): Boolean {
+        val minus = query.startsWith("-")
+        val tag = if (minus) { query.substringAfter("-") } else query
+        val containsGenre by lazy { containsGenre(query, genres) }
+        return when (sourceName.contains(tag, true)) {
+            false -> containsGenre
+            else -> !minus
         }
     }
 


### PR DESCRIPTION
This PR adds an option search in library using -source 
i.e. search for all manga *not* in a particular source  

A problem when you directly add a negation check is that although
it is working, the genre search kicks in to add back every manga since
-<source> returns true for containsGenre()

Solution chosen was to check source search first, and then if it fails
move to genre check. 
In addition, now you're able to search like this:
Eg: 
 1. -isekai, fantasy, -local, komga
 2. -manganato, -mangakakalot, -local

Checked in following devices:
 - Pixel 3 (blueline)
 - Redmi 7 (onclite)
 
Closes https://github.com/tachiyomiorg/tachiyomi/issues/4846

_______________________________________________________
This was already present in Sy however it heavily relied to methods
defined in exh. This PR tries a different approach

I understand that Multiple layers of if statements might not be always
preferable. If there's any way I can improve this, let me know :d 