### PR TITLE
Move "Clear history" out from overflow

### DIFF
--- a/app/src/main/res/drawable/ic_delete_sweep_24dp.xml
+++ b/app/src/main/res/drawable/ic_delete_sweep_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M15,16h4v2h-4zM15,8h7v2h-7zM15,12h6v2h-6zM3,18c0,1.1 0.9,2 2,2h6c1.1,0 2,-0.9 2,-2L13,8L3,8v10zM14,5h-3l-1,-1L6,4L5,5L2,5v2h12z" />
+</vector>

--- a/app/src/main/res/menu/history.xml
+++ b/app/src/main/res/menu/history.xml
@@ -12,7 +12,9 @@
 
     <item
         android:id="@+id/action_clear_history"
+        android:icon="@drawable/ic_delete_sweep_24dp"
         android:title="@string/pref_clear_history"
-        app:showAsAction="never" />
+        app:iconTint="?attr/colorOnPrimary"
+        app:showAsAction="ifRoom" />
 
 </menu>


### PR DESCRIPTION
Places it as its own icon, having an overflow with only one item doesn't make much sense when that's not the behavior in other parts of the app.

First I thought it might potentially be destructive to have it so open, but:
- There is a prompt telling the user exactly what will happen.
- If the user is... skilled enough to dodge the prompt and delete it anyways, backups should contain that information too.
- If the user does not have a backup with it either, the next Darwin awards are probably not too far out and hopefully the user is taught a valuable lesson.

## Tested
- **Android 10** with **Huawei Mate 20 Pro**.

## Comparisons

| New | Old |
| ----- | ---- |
| ![New](https://user-images.githubusercontent.com/10836780/121829504-046eee80-ccc3-11eb-96b8-87e5e2659fca.png) | ![Old](https://user-images.githubusercontent.com/10836780/121829506-0769df00-ccc3-11eb-831c-cc014842deb6.png) |