### PR TITLE
Fix crash when opening the MangaController from the browse search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -296,7 +296,7 @@ class MangaController :
         val scrolledList = binding.fullRecycler ?: binding.infoRecycler!!
         if (toolbarTextView == null) {
             toolbarTextView = (activity as? MainActivity)?.binding?.toolbar?.children
-                ?.find { it is TextView } as TextView
+                ?.find { it is TextView } as? TextView
         }
         toolbarTextView?.alpha = when {
             // Specific alpha provided


### PR DESCRIPTION
null safe cast to TextView because when searching for manga in a source,
the toolbar has no children and
find() returns null.