### PR TITLE
Apply reader theme to reader progress dialog

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -445,6 +445,7 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="switchStyle">@style/Theme.Widget.BasicSwitch</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>
+        <item name="android:alertDialogTheme">@style/Theme.AlertDialog.Light</item>
     </style>
 
     <!--== Light Reader ==-->
@@ -468,6 +469,7 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="switchStyle">@style/Theme.Widget.BasicSwitch</item>
         <item name="bottomSheetDialogTheme">@style/Theme.BottomSheet</item>
+        <item name="android:alertDialogTheme">@style/Theme.AlertDialog.Amoled</item>
     </style>
 
     <!--== Dark Reader ==-->
@@ -480,6 +482,10 @@
 
         <!-- Base background/text colors -->
         <item name="android:colorBackground">@color/backgroundDark</item>
+
+        <!-- Alert Dialog -->
+        <item name="android:alertDialogTheme">@style/Theme.AlertDialog.Dark</item>
+
     </style>
 
     <!--===============-->


### PR DESCRIPTION
This PR styles the progress dialog that appears when clicking the previous or next chapter buttons to use a style matching the current reader theme, and is more Tachiyomi-styled.

# Before
White | Gray, Black, Automatic
-------|-------------
![old_white_progress](https://user-images.githubusercontent.com/25621728/122648088-a9833000-d0e4-11eb-8120-6107c3cc66b1.jpg) | ![old_dark_progress](https://user-images.githubusercontent.com/25621728/122648097-b9027900-d0e4-11eb-8cbe-085d369aec54.jpg)

# After
White | Gray | Black, Automatic
-------|-------|-------
![new_white_progress](https://user-images.githubusercontent.com/25621728/122648133-f49d4300-d0e4-11eb-90ec-d738140cc0df.jpg) | ![new_gray_progress](https://user-images.githubusercontent.com/25621728/122648138-f9fa8d80-d0e4-11eb-8bd5-c59473fe60d0.jpg) | ![new_black_progress](https://user-images.githubusercontent.com/25621728/122648147-00890500-d0e5-11eb-8a73-1293d026a500.jpg)



