### PR TITLE
Add favorited badge to browse and search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceComfortableGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceComfortableGridHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
 import android.view.View
+import androidx.core.view.isVisible
 import coil.clear
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -36,6 +37,12 @@ class SourceComfortableGridHolder(private val view: View, private val adapter: F
 
         // Set alpha of thumbnail.
         binding.thumbnail.alpha = if (manga.favorite) 0.3f else 1.0f
+
+        // For rounded corners
+        binding.badges.clipToOutline = true
+
+        // Set favorite badge
+        binding.favoriteText.isVisible = manga.favorite
 
         setImage(manga)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceGridHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
 import android.view.View
+import androidx.core.view.isVisible
 import coil.clear
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -36,6 +37,12 @@ open class SourceGridHolder(private val view: View, private val adapter: Flexibl
 
         // Set alpha of thumbnail.
         binding.thumbnail.alpha = if (manga.favorite) 0.3f else 1.0f
+
+        // For rounded corners
+        binding.badges.clipToOutline = true
+
+        // Set favorite badge
+        binding.favoriteText.isVisible = manga.favorite
 
         setImage(manga)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceListHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
 import android.view.View
+import androidx.core.view.isVisible
 import coil.clear
 import coil.loadAny
 import coil.transform.RoundedCornersTransformation
@@ -39,6 +40,12 @@ class SourceListHolder(private val view: View, adapter: FlexibleAdapter<*>) :
 
         // Set alpha of thumbnail.
         binding.thumbnail.alpha = if (manga.favorite) 0.3f else 1.0f
+
+        // For rounded corners
+        binding.badges.clipToOutline = true
+
+        // Set favorite badge
+        binding.favoriteText.isVisible = manga.favorite
 
         setImage(manga)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchCardHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchCardHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source.globalsearch
 
 import android.view.View
+import androidx.core.view.isVisible
 import coil.clear
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -36,9 +37,17 @@ class GlobalSearchCardHolder(view: View, adapter: GlobalSearchCardAdapter) :
     fun bind(manga: Manga) {
         binding.card.clipToOutline = true
 
+        // Set manga title
         binding.title.text = manga.title
+
         // Set alpha of thumbnail.
         binding.cover.alpha = if (manga.favorite) 0.3f else 1.0f
+
+        // For rounded corners
+        binding.badges.clipToOutline = true
+
+        // Set favorite badge
+        binding.favoriteText.isVisible = manga.favorite
 
         setImage(manga)
     }

--- a/app/src/main/res/layout/global_search_controller_card_item.xml
+++ b/app/src/main/res/layout/global_search_controller_card_item.xml
@@ -38,6 +38,32 @@
             tools:ignore="ContentDescription"
             tools:src="@mipmap/ic_launcher" />
 
+        <LinearLayout
+            android:id="@+id/badges"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/rounded_rectangle">
+
+            <TextView
+                android:id="@+id/favorite_text"
+                style="@style/TextAppearance.Regular.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/colorSecondary"
+                android:maxLines="1"
+                android:paddingStart="3dp"
+                android:paddingTop="1dp"
+                android:paddingEnd="3dp"
+                android:paddingBottom="1dp"
+                android:text="@string/in_library"
+                android:textColor="?attr/colorOnSecondary"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+        </LinearLayout>
+
     </FrameLayout>
 
     <TextView

--- a/app/src/main/res/layout/source_comfortable_grid_item.xml
+++ b/app/src/main/res/layout/source_comfortable_grid_item.xml
@@ -84,6 +84,22 @@
                     tools:text="120"
                     tools:visibility="visible" />
 
+                <TextView
+                    android:id="@+id/favorite_text"
+                    style="@style/TextAppearance.Regular.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/colorSecondary"
+                    android:maxLines="1"
+                    android:paddingStart="3dp"
+                    android:paddingTop="1dp"
+                    android:paddingEnd="3dp"
+                    android:paddingBottom="1dp"
+                    android:text="@string/in_library"
+                    android:textColor="?attr/colorOnSecondary"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
             </LinearLayout>
 
             <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/app/src/main/res/layout/source_compact_grid_item.xml
+++ b/app/src/main/res/layout/source_compact_grid_item.xml
@@ -83,6 +83,22 @@
                 tools:text="120"
                 tools:visibility="visible" />
 
+            <TextView
+                android:id="@+id/favorite_text"
+                style="@style/TextAppearance.Regular.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/colorSecondary"
+                android:maxLines="1"
+                android:paddingStart="3dp"
+                android:paddingTop="1dp"
+                android:paddingEnd="3dp"
+                android:paddingBottom="1dp"
+                android:text="@string/in_library"
+                android:textColor="?attr/colorOnSecondary"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/source_list_item.xml
+++ b/app/src/main/res/layout/source_list_item.xml
@@ -97,6 +97,22 @@
             tools:text="130"
             tools:visibility="visible" />
 
+        <TextView
+            android:id="@+id/favorite_text"
+            style="@style/TextAppearance.Regular.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSecondary"
+            android:maxLines="1"
+            android:paddingStart="3dp"
+            android:paddingTop="1dp"
+            android:paddingEnd="3dp"
+            android:paddingBottom="1dp"
+            android:text="@string/in_library"
+            android:textColor="?attr/colorOnSecondary"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Inspired by TachiJ2K where the favorite status is more than just a lower cover alpha.

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- `Browse`/`Latest` with all reading modes.
- `Global search` and `Migrate`.
- `Portrait` and `Landscape`.
- Base themes.

## Comparisons

| New browse (Compact) | Old browse (Compact) | 
| -------------------------- | ------------------------- |
| ![New browse (Compact)](https://user-images.githubusercontent.com/10836780/122912709-ea837a80-d358-11eb-8bc4-4ac0dafa687a.png) | ![Old browse (Compact)](https://user-images.githubusercontent.com/10836780/122912722-eeaf9800-d358-11eb-9545-9511f28aa18b.png) |

| New browse (List) | Old browse (List) | 
| -------------------- | ------------------ |
| ![New browse (List)](https://user-images.githubusercontent.com/10836780/122912930-24548100-d359-11eb-99f9-13793199ea87.png) | ![Old browse (List)](https://user-images.githubusercontent.com/10836780/122912804-04bd5880-d359-11eb-93ec-df7cb076257c.png) |

| New search | Old search | 
| ------------- | ------------ |
| ![New search](https://user-images.githubusercontent.com/10836780/122912879-14d53800-d359-11eb-956e-51c7c4580c64.png) | ![Old search](https://user-images.githubusercontent.com/10836780/122912890-1868bf00-d359-11eb-95fc-2f808c3aa6a1.png) |

