### PR TITLE
Hide Start/Resume FAB unless there are unread chapters and during loading

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -270,6 +270,8 @@ class MangaController :
         chaptersAdapter?.fastScroller = binding.fastScroller
 
         actionFabScrollListener = actionFab?.shrinkOnScroll(chapterRecycler)
+        // Initially set FAB invisible; will become visible if unread chapters are present
+        actionFab?.isVisible = false
 
         binding.swipeRefresh.refreshes()
             .onEach {
@@ -339,6 +341,11 @@ class MangaController :
                         }
                     )
                 }
+                /*
+                This else branch shouldn't ever be reached, since
+                the FAB is hidden when there's no unread chapters,
+                but there's no harm in keeping it in.
+                 */
             } else {
                 view?.context?.toast(R.string.no_next_chapter)
             }
@@ -739,8 +746,14 @@ class MangaController :
         }
 
         val context = view?.context
-        if (context != null && chapters.any { it.read }) {
-            actionFab?.text = context.getString(R.string.action_resume)
+        val unreadChapters = chapters.count { !it.read }
+        if (unreadChapters > 0) {
+            actionFab?.isVisible = true
+            if (context != null && unreadChapters < chapters.size) {
+                actionFab?.text = context.getString(R.string.action_resume)
+            }
+        } else {
+            actionFab?.isVisible = false
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -341,13 +341,6 @@ class MangaController :
                         }
                     )
                 }
-                /*
-                This else branch shouldn't ever be reached, since
-                the FAB is hidden when there's no unread chapters,
-                but there's no harm in keeping it in.
-                 */
-            } else {
-                view?.context?.toast(R.string.no_next_chapter)
             }
         }
     }
@@ -746,14 +739,11 @@ class MangaController :
         }
 
         val context = view?.context
-        val unreadChapters = chapters.count { !it.read }
-        if (unreadChapters > 0) {
-            actionFab?.isVisible = true
-            if (context != null && unreadChapters < chapters.size) {
+        if (context != null) {
+            actionFab?.isVisible = chapters.any { !it.read }
+            if (chapters.any { it.read }) {
                 actionFab?.text = context.getString(R.string.action_resume)
             }
-        } else {
-            actionFab?.isVisible = false
         }
     }
 


### PR DESCRIPTION
This PR hides the Start/Resume FAB when viewing Manga info and chapters, and only shows it if there are unread chapters for the manga.

This addresses the fact that while the chapter list is loading, or when all chapters are read, the FAB is unneeded and does nothing (besides showing a Toast that there's no next chapters), as well as being slightly misleading with it's label. (Such as showing "Start" when there are no chapters, or "Resume" when there's currently no more chapters to read).