### PR TITLE
Create parity with extension repo issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: ⚠️ Extension/source issue
     url: https://github.com/tachiyomiorg/tachiyomi-extensions/issues/new/choose
-    about: Issues and requests for extensions and sources should be opened in the tachiyomi-extensions repository instead.
+    about: Issues and requests for extensions and sources should be opened in the tachiyomi-extensions repository instead
   - name: 📦 Tachiyomi extensions
     url: https://github.com/tachiyomiorg/tachiyomi-extensions
-    about: Extensions and sources.
-  - name: 🌐 Tachiyomi website
+    about: List of all available extensions with download links
+  - name: 🖥️ Tachiyomi website
     url: https://tachiyomi.org/help/
-    about: Guides, troubleshooting, and answers to common questions.
+    about: Guides, troubleshooting, and answers to common questions

--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -1,5 +1,5 @@
-name: 🐞 Bug report
-description: Report a bug in Tachiyomi
+name: 🐞 Issue report
+description: Report an issue in Tachiyomi
 labels: [Bug]
 body:
 
@@ -58,12 +58,12 @@ body:
     id: reproduce-steps
     attributes:
       label: Steps to reproduce
-      description: Provide an example of how to trigger the bug.
+      description: Provide an example of the issue.
       placeholder: |
         Example:
           1. First step
           2. Second step
-          3. Bug occurs
+          3. Issue here
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -1,5 +1,5 @@
 name: ⭐ Feature request
-description: Suggest a feature for Tachiyomi
+description: Suggest a feature to improve Tachiyomi
 labels: [Feature request]
 body:
 


### PR DESCRIPTION
Created in tandem with tachiyomiorg/tachiyomi-extensions#7914

- Renames the issue form templates to match the extensions repo ones.
- Changes the website icon as it was the same used for the **Source requests** in the extensions repo.
- Better description for the website extensions link.
- Removed ending period to match the issue templates.
- Renames "Bug report" to "Issue report", matches the extensions repo.
  - Issue can be both bugs and annoyances, not just one or the other.