### PR TITLE
Enable users to manually set manga status for library manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -19,6 +19,26 @@ interface Manga : SManga {
 
     var viewer_flags: Int
 
+    /** The publication status that should be used when taking actions dependent on a
+     * manga status.
+     * This takes into account the real (source) status, and the user-defined status.
+     *
+     * Setting this value is the same as setting [sourcePublicationStatus]
+     */
+    var publicationStatus: Int
+        get() = if (status >= 0x0F) status shr 4 else status
+        set(value) { status = (status and 0xF0) or value }
+
+    /** The publication status as reported by the source of this manga */
+    var sourcePublicationStatus: Int
+        get() = status and 0x0F
+        set(value) { status = (status and 0xF0) or value }
+
+    /** The publication status set by the user */
+    var overridePublicationStatus: Int
+        get() = status shr 4
+        set(value) { status = (status and 0x0F) or (value shl 4) }
+
     var chapter_flags: Int
 
     var cover_last_modified: Long

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -251,7 +251,7 @@ class LibraryUpdateService(
             listToInclude.minus(listToExclude)
         }
         if (target == Target.CHAPTERS && preferences.updateOnlyNonCompleted()) {
-            listToUpdate = listToUpdate.filterNot { it.status == SManga.COMPLETED }
+            listToUpdate = listToUpdate.filterNot { it.publicationStatus == SManga.COMPLETED }
         }
 
         val selectedScheme = preferences.libraryUpdatePrioritization().get()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/Source.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/Source.kt
@@ -65,8 +65,13 @@ interface Source : tachiyomi.source.Source {
     @Suppress("DEPRECATION")
     override suspend fun getMangaDetails(manga: MangaInfo): MangaInfo {
         val sManga = manga.toSManga()
+        // Pull out and seperate the source status from the user status
+        val userPubStat = sManga.status and 0xF0
+        sManga.status = sManga.status and 0x0F
+
         val networkManga = fetchMangaDetails(sManga).awaitSingle()
         sManga.copyFrom(networkManga)
+        sManga.status = userPubStat or sManga.status
         return sManga.toMangaInfo()
     }
 
@@ -75,7 +80,9 @@ interface Source : tachiyomi.source.Source {
      */
     @Suppress("DEPRECATION")
     override suspend fun getChapterList(manga: MangaInfo): List<ChapterInfo> {
-        return fetchChapterList(manga.toSManga()).awaitSingle()
+        val sManga = manga.toSManga()
+        sManga.status = sManga.status and 0x0F
+        return fetchChapterList(sManga).awaitSingle()
             .map { it.toChapterInfo() }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -133,7 +133,7 @@ class LibraryPresenter(
 
         val filterFnCompleted: (LibraryItem) -> Boolean = completed@{ item ->
             if (filterCompleted == State.IGNORE.value) return@completed true
-            val isCompleted = item.manga.status == SManga.COMPLETED
+            val isCompleted = item.manga.publicationStatus == SManga.COMPLETED
 
             return@completed if (filterCompleted == State.INCLUDE.value) isCompleted
             else !isCompleted

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -45,10 +45,7 @@ import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.base.controller.FabController
-import eu.kanade.tachiyomi.ui.base.controller.NucleusController
-import eu.kanade.tachiyomi.ui.base.controller.ToolbarLiftOnScrollController
-import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
+import eu.kanade.tachiyomi.ui.base.controller.*
 import eu.kanade.tachiyomi.ui.browse.migration.search.SearchController
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceController
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchController
@@ -64,6 +61,7 @@ import eu.kanade.tachiyomi.ui.manga.chapter.DeleteChaptersDialog
 import eu.kanade.tachiyomi.ui.manga.chapter.DownloadCustomChaptersDialog
 import eu.kanade.tachiyomi.ui.manga.chapter.MangaChaptersHeaderAdapter
 import eu.kanade.tachiyomi.ui.manga.chapter.base.BaseChaptersAdapter
+import eu.kanade.tachiyomi.ui.manga.info.ChangeMangaPublicationStatusDialog
 import eu.kanade.tachiyomi.ui.manga.info.MangaInfoHeaderAdapter
 import eu.kanade.tachiyomi.ui.manga.track.TrackItem
 import eu.kanade.tachiyomi.ui.manga.track.TrackSearchDialog
@@ -102,6 +100,7 @@ class MangaController :
     BaseChaptersAdapter.OnChapterClickListener,
     ChangeMangaCoverDialog.Listener,
     ChangeMangaCategoriesDialog.Listener,
+    ChangeMangaPublicationStatusDialog.Listener,
     DownloadCustomChaptersDialog.Listener,
     DeleteChaptersDialog.Listener {
 
@@ -568,7 +567,18 @@ class MangaController :
                 }
             }
         }
+        mangaInfoAdapter?.notifyDataSetChanged()
+    }
 
+    fun onPublicationStatusClick() {
+        val manga = presenter.manga
+        if (!manga.favorite) return
+        ChangeMangaPublicationStatusDialog(this, manga.sourcePublicationStatus, manga.overridePublicationStatus)
+            .showDialog(router)
+    }
+
+    override fun updatePublicationStatusForManga(sourceStatus: Int, overrideStatus: Int) {
+        presenter.setMangaStatus(sourceStatus, overrideStatus)
         mangaInfoAdapter?.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -215,6 +215,7 @@ class MangaPresenter(
         }
         if (!manga.favorite) {
             manga.removeCovers(coverCache)
+            manga.overridePublicationStatus = 0 // clear custom publication status
         }
         db.insertManga(manga).executeAsBlocking()
         return manga.favorite
@@ -317,6 +318,12 @@ class MangaPresenter(
                 { view, _ -> view.onSetCoverSuccess() },
                 { view, e -> view.onSetCoverError(e) }
             )
+    }
+
+    fun setMangaStatus(sourceStatus: Int, overrideStatus: Int) {
+        manga.sourcePublicationStatus = sourceStatus
+        manga.overridePublicationStatus = overrideStatus
+        db.insertManga(manga).executeAsBlocking()
     }
 
     // Manga info - end

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/ChangeMangaPublicationStatusDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/ChangeMangaPublicationStatusDialog.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.ui.manga.info
+
+import android.app.Dialog
+import android.os.Bundle
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.list.listItemsSingleChoice
+import com.bluelinelabs.conductor.Controller
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.ui.base.controller.DialogController
+
+class ChangeMangaPublicationStatusDialog<T>(bundle: Bundle? = null) :
+    DialogController(bundle) where T : Controller, T : ChangeMangaPublicationStatusDialog.Listener {
+
+    private var realStatus: Int = SManga.UNKNOWN
+    private var overrideStatus: Int = SManga.UNKNOWN
+
+    constructor(
+        target: T,
+        realStatus: Int,
+        overrideStatus: Int
+    ) : this() {
+        targetController = target
+        this.realStatus = realStatus
+        this.overrideStatus = overrideStatus
+    }
+
+    override fun onCreateDialog(savedViewState: Bundle?): Dialog {
+        return MaterialDialog(activity!!)
+            .title(R.string.set_manga_status)
+            .listItemsSingleChoice(
+                res = R.array.manga_override_status_options,
+                initialSelection = overrideStatus,
+            ) { _, index, _ ->
+                (targetController as? Listener)?.updatePublicationStatusForManga(realStatus, index)
+            }
+            .positiveButton(android.R.string.ok)
+            .negativeButton(android.R.string.cancel)
+    }
+
+    interface Listener {
+        fun updatePublicationStatusForManga(sourceStatus: Int, overrideStatus: Int)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoHeaderAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoHeaderAdapter.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.manga.info
 
+import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -145,6 +146,14 @@ class MangaInfoHeaderAdapter(
                 }
                 .launchIn(controller.viewScope)
 
+            if (controller.presenter.manga.favorite) {
+                binding.mangaStatus.clicks()
+                    .onEach {
+                        controller.onPublicationStatusClick()
+                    }
+                    .launchIn(controller.viewScope)
+            }
+
             binding.mangaAuthor.clicks()
                 .onEach {
                     controller.performGlobalSearch(binding.mangaAuthor.text.toString())
@@ -231,12 +240,18 @@ class MangaInfoHeaderAdapter(
 
             // Update status TextView.
             binding.mangaStatus.setText(
-                when (manga.status) {
+                when (manga.publicationStatus) {
                     SManga.ONGOING -> R.string.ongoing
                     SManga.COMPLETED -> R.string.completed
                     SManga.LICENSED -> R.string.licensed
                     else -> R.string.unknown_status
                 }
+            )
+
+            // Set status text as italic if it has been manually set
+            binding.mangaStatus.setTypeface(
+                null,
+                if (manga.overridePublicationStatus != 0) Typeface.ITALIC else Typeface.NORMAL
             )
 
             // Set the favorite drawable to the correct one.

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -104,4 +104,12 @@
         <item>@string/edge_nav</item>
         <item>@string/right_and_left_nav</item>
     </string-array>
+
+    <string-array name="manga_override_status_options">
+        <!-- This string says "Default" so we're using it here, rather than making new string -->
+        <item>@string/default_viewer</item>
+        <item>@string/ongoing</item>
+        <item>@string/completed</item>
+        <item>@string/licensed</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -538,6 +538,7 @@
     <string name="clipboard_copy_error">Failed to copy to clipboard</string>
     <string name="source_not_installed">Source not installed: %1$s</string>
     <string name="snack_add_to_library">Add manga to library?</string>
+    <string name="set_manga_status">Set Manga Status</string>
 
     <!-- Manga chapters fragment -->
     <string name="display_mode_chapter">Chapter %1$s</string>


### PR DESCRIPTION
The idea with this PR is to let users to have slightly more control over their library (and solving a couple of problems) by manually specifying the status that should be taken into account wherever the app queries the status of a manga (Eg. The "Completed" library filter, the "Only Update Ongoing Manga" setting, etc).

## Implementation
Since status field in the database is a (presumably) 1 byte integer, I have elected to use this value to store both what the _actual_ status of the manga is and what the user set the status to by dedicating 4 bits of the byte to each.
* The lower 4 bits store the status of the manga (as reported by the source)
* The upper 4 bits store the status of the manga as set by the user

Using 4 bits to track the status; there can be up to 16 different statuses for a manga. At least for now, I think this is an acceptable limit, as there are currently only 4 different statuses.
Though while working on this, I did notice that it looks like the 5th and 6th options have been designated already.

Code that needs to get the status of a manga (through the Manga interface) can use a new getter, `publicationStatus`, which returns the status the user set, or what the actual status is if there is no user-set status. There are also getters and setters for the real status and user-set status. All of these getters and setters just perform bitwise-logic on the parent-interface SManga's `status` field.

## Extension Compatibility
If I've done everything right, extensions need no changes at all, as extensions are passed the actual status of the manga, not the user-set status. I chose this to remove any possible side-effects of extensions having a different status than expected.

## UI
On the UI side of things, to change the manga status I have made it so that clicking on the status text of a _favorited_ manga will bring up a dialog of status options (Default, Ongoing, Completed, Licensed), that the user can use to select. Of note, the "Default" option means no user-set value, and the app will use what the actual status is from the source. Additionally, when removing a manga from the library, the user status is cleared,

To indicate to the user that a custom status is applied, the status text becomes _italic_ when there is a custom value set.
| Preview |
|----------|
| ![status_sample](https://user-images.githubusercontent.com/25621728/124213059-31861400-daad-11eb-8bf4-b5e2bdd77fbe.png) |

### P.S
I apologize for the wall-of-text PR, I just wanted to make sure I covered everything important, since this is the biggest and most complex PR I have created for Tachiyomi so far.