### PR TITLE
Sanitize manga title in page download subfolder name

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -596,7 +596,7 @@ class ReaderPresenter(
         // Pictures directory.
         val baseDir = getPicturesDir(context).absolutePath
         val destDir = if (preferences.folderPerManga()) {
-            File(baseDir + File.separator + manga.title)
+            File(baseDir + File.separator + DiskUtil.buildValidFilename(manga.title))
         } else {
             File(baseDir)
         }


### PR DESCRIPTION
The newly added option to save pages to separate subfolders based on manga title didn't sanitize the manga title in the subfolders' names, which made it impossible to save pages from manga with reserved characters in their titles with the option enabled. This commit aims to fix that by using `DiskUtil.buildValidFilename` to sanitize it.

Side note: Kotlin and pull requests are both things I've never done before so I really hope I didn't mess anything up with this small change. I've tested it in Android Studio's emulator and it worked as expected.