### PR TITLE
Show correct number of items in the library title

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -147,11 +147,8 @@ class LibraryController(
 
         if (preferences.categoryNumberOfItems().get() && libraryMangaRelay.hasValue()) {
             libraryMangaRelay.value.mangas.let { mangaMap ->
-                if (!showCategoryTabs) {
+                if (!showCategoryTabs || adapter?.categories?.size == 1) {
                     title += " (${mangaMap[currentCategory?.id]?.size ?: 0})"
-                } else if (adapter?.categories?.size == 1) {
-                    // Only "Default" category
-                    title += " (${mangaMap[0]?.size ?: 0})"
                 }
             }
         }


### PR DESCRIPTION
When all manga are in a category that isn't the default category, the title just shows the number of items in the default category. This fixes that.

The next comment shows how to reproduce