### PR TITLE
Allow Search with same query on network state change..

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
@@ -324,11 +324,6 @@ open class BrowseSourceController(bundle: Bundle) :
      * @param newQuery the new query.
      */
     fun searchWithQuery(newQuery: String) {
-        // If text didn't change, do nothing
-        if (presenter.query == newQuery) {
-            return
-        }
-
         showProgressBar()
         adapter?.clear()
 


### PR DESCRIPTION
Sometime it may be needed to search with same query. And again I don't actually see a real reason for this check.