### PR TITLE
Support more image formats for covers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -23,6 +23,7 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import eu.kanade.tachiyomi.data.coil.ByteBufferFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher
+import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.network.NetworkHelper
@@ -105,6 +106,7 @@ open class App : Application(), LifecycleObserver, ImageLoaderFactory {
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this).apply {
             componentRegistry {
+                add(TachiyomiImageDecoder(this@App.resources))
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     add(ImageDecoderDecoder(this@App))
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -1,0 +1,51 @@
+package eu.kanade.tachiyomi.data.coil
+
+import android.content.res.Resources
+import androidx.core.graphics.drawable.toDrawable
+import coil.bitmap.BitmapPool
+import coil.decode.DecodeResult
+import coil.decode.Decoder
+import coil.decode.Options
+import coil.size.Size
+import eu.kanade.tachiyomi.util.system.ImageUtil
+import okio.BufferedSource
+import tachiyomi.decoder.ImageDecoder
+
+/**
+ * A [Decoder] that uses built-in [ImageDecoder] to decode images that is not supported by the system.
+ */
+class TachiyomiImageDecoder(private val resources: Resources) : Decoder {
+
+    override fun handles(source: BufferedSource, mimeType: String?): Boolean {
+        val type = source.peek().inputStream().use {
+            ImageUtil.findImageType(it)
+        }
+        return when (type) {
+            ImageUtil.ImageType.AVIF, ImageUtil.ImageType.JXL -> true
+            else -> false
+        }
+    }
+
+    override suspend fun decode(
+        pool: BitmapPool,
+        source: BufferedSource,
+        size: Size,
+        options: Options
+    ): DecodeResult {
+        val decoder = source.use {
+            ImageDecoder.newInstance(it.inputStream())
+        }
+
+        check(decoder != null && decoder.width > 0 && decoder.height > 0) { "Failed to initialize decoder." }
+
+        val bitmap = decoder.decode(rgb565 = options.allowRgb565)
+        decoder.recycle()
+
+        check(bitmap != null) { "Failed to decode image." }
+
+        return DecodeResult(
+            drawable = bitmap.toDrawable(resources),
+            isSampled = false
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.coil
 
 import android.content.res.Resources
+import android.os.Build
 import androidx.core.graphics.drawable.toDrawable
 import coil.bitmap.BitmapPool
 import coil.decode.DecodeResult
@@ -22,6 +23,7 @@ class TachiyomiImageDecoder(private val resources: Resources) : Decoder {
         }
         return when (type) {
             ImageUtil.ImageType.AVIF, ImageUtil.ImageType.JXL -> true
+            ImageUtil.ImageType.HEIF -> Build.VERSION.SDK_INT < Build.VERSION_CODES.O
             else -> false
         }
     }


### PR DESCRIPTION
This will use reader's image decoder to decode cover images if its format is unsupported by the system. Note that currently there is no optimizations when TachiyomiImageDecoder is used so it might be problematic on larger images.

Resolves #5451
Resolves #5522