### PR TITLE
Tweak chip contrast

### DIFF
--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -32,4 +32,7 @@
 
     <attr name="lightSystemBarsOnPrimary" format="reference|boolean"/>
 
+    <!-- Setting chip color values for specific themes -->
+    <attr name="chipTextColor" format="reference|integer"/>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,6 +29,7 @@
     <color name="accent_yinyang">#000000</color>
     <color name="color_on_secondary_yinyang">#FFFFFF</color>
     <color name="ripple_colored_yinyang">#999999</color>
+    <color name="chip_text_yinyang">#000000</color>
 
     <!-- Midnight Dusk Theme -->
     <color name="accent_midnightdusk">#F02475</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -187,8 +187,8 @@
     <style name="Widget.Tachiyomi.Chip.Action" parent="Widget.MaterialComponents.Chip.Action">
         <item name="chipStrokeWidth">1dp</item>
         <item name="chipStrokeColor">?attr/colorPrimary</item>
-        <item name="chipBackgroundColor">@android:color/transparent</item>
-        <item name="android:textColor">?attr/colorPrimary</item>
+        <item name="chipBackgroundColor">?attr/chipBackgroundColor</item>
+        <item name="android:textColor">?attr/chipTextColor</item>
         <item name="rippleColor">?attr/colorControlHighlight</item>
 
         <!-- Custom chip states -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -121,6 +121,10 @@
         <item name="colorTertiary">@color/color_on_secondary_yinyang</item>
         <item name="colorOnTertiary">@color/accent_yinyang</item>
         <item name="colorControlHighlight">@color/ripple_colored_yinyang</item>
+
+        <!-- Themes -->
+        <item name="chipTextColor">@color/color_on_secondary_yinyang</item>
+        <item name="chipBackgroundColor">@color/accent_yinyang</item>
     </style>
 
     <!--== Midnight Dusk theme ==-->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -54,6 +54,8 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.Tachiyomi.BottomSheetDialog</item>
         <item name="chipStyle">@style/Widget.Tachiyomi.Chip.Action</item>
+        <item name="chipTextColor">?android:attr/textColorPrimary</item>
+        <item name="chipBackgroundColor">?attr/colorControlHighlight</item>
         <item name="snackbarStyle">@style/Widget.Tachiyomi.Snackbar</item>
         <item name="snackbarTextViewStyle">@style/Widget.Tachiyomi.Snackbar.TextView</item>
         <item name="textInputStyle">@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox</item>


### PR DESCRIPTION
Resolves some of the issues mentioned in #5506

Yin & Yang theme got its chip color sets seperately (and approved by creator) as it didn't look as good following the regular automatic styling.

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- All themes.

## Comparisons
Compared using the Yotsuba  theme, which was one of the low contrast ones.
| New (Light) | Old (Light) |
| ------------- | ----------- |
| ![New 1](https://user-images.githubusercontent.com/10836780/125191846-d985a500-e244-11eb-903c-c2e1e7f0005b.png) | ![Old 1](https://user-images.githubusercontent.com/10836780/125191851-dd192c00-e244-11eb-85f6-1c5dfade52b4.png) |

| New (Dark) | Old (Dark) |
| ------------- | ----------- |
| ![New 2](https://user-images.githubusercontent.com/10836780/125191881-f02bfc00-e244-11eb-8803-672f3dc8ea5c.png) | ![Old 2](https://user-images.githubusercontent.com/10836780/125191885-f326ec80-e244-11eb-8f2e-0b3a86c4d70a.png) |

