### PR TITLE
Improve Green Apple color in Light mode

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -19,4 +19,14 @@
         <item name="android:colorBackground">@color/background_midnightdusk</item>
     </style>
 
+    <!--== Green Apple theme ==-->
+    <style name="Theme.Tachiyomi.GreenApple">
+        <!-- Theme colors -->
+        <item name="colorPrimary">@color/accent_greenapple</item>
+        <item name="colorOnPrimary">@color/md_black_1000</item>
+        <item name="colorTertiary">@color/md_blue_A400</item>
+        <item name="colorControlHighlight">@color/ripple_colored_greenapple</item>
+        <item name="lightSystemBarsOnPrimary">true</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -23,6 +23,7 @@
 
     <!-- Green Apple Theme -->
     <color name="accent_greenapple">#48E484</color>
+    <color name="accent_greenapple_variant">#188140</color>
     <color name="ripple_colored_greenapple">#1F48E484</color>
 
     <!-- Yin Yang Theme -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -104,8 +104,8 @@
     <!--== Green Apple theme ==-->
     <style name="Theme.Tachiyomi.GreenApple">
         <!-- Theme colors -->
-        <item name="colorPrimary">@color/accent_greenapple</item>
-        <item name="colorOnPrimary">@color/md_black_1000</item>
+        <item name="colorPrimary">@color/accent_greenapple_variant</item>
+        <item name="colorOnPrimary">@color/md_white_1000</item>
         <item name="colorTertiary">@color/md_blue_A400</item>
         <item name="colorControlHighlight">@color/ripple_colored_greenapple</item>
         <item name="lightSystemBarsOnPrimary">true</item>


### PR DESCRIPTION
Resolves some of the issues mentioned in #5506
Not the same kind of Green color anymore, but it looks good? Contrast at least isn't shit

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- **Green Apple** in both light and dark modes.

## Comparisons
| New | Old |
| ----- | ---- |
| ![New](https://user-images.githubusercontent.com/10836780/125193411-9c251580-e24c-11eb-90ba-c7f489ad6346.png) | ![Old](https://user-images.githubusercontent.com/10836780/125193414-9e876f80-e24c-11eb-835b-a4f135a718a9.png) |