### PR TITLE
fix yin & yang theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -117,6 +117,7 @@
     <style name="Theme.Tachiyomi.YinYang">
         <!-- Theme colors -->
         <item name="colorPrimary">@color/accent_yinyang</item>
+        <item name="colorOnPrimary">@color/color_on_secondary_yinyang</item>
         <item name="colorOnSecondary">@color/color_on_secondary_yinyang</item>
         <item name="colorTertiary">@color/color_on_secondary_yinyang</item>
         <item name="colorOnTertiary">@color/accent_yinyang</item>


### PR DESCRIPTION
refresh arrow color didnt change in dark mode

previously only look like white circle
![image](https://user-images.githubusercontent.com/16263232/125234883-c7bb0500-e30b-11eb-98cf-e5520469492d.png)
