### PR TITLE
Update Libary update notification.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -74,7 +74,7 @@ class LibraryUpdateNotifier(private val context: Context) {
                 .setContentTitle(context.getString(R.string.notification_check_updates))
                 .setContentText("($current/$total)")
         } else {
-            val updatingText = manga.joinToString("\n") { it.title }
+            val updatingText = manga.joinToString("\n") { "• ${it.title}" }
             progressNotificationBuilder
                 .setContentTitle(context.getString(R.string.notification_updating, current, total))
                 .setStyle(NotificationCompat.BigTextStyle().bigText(updatingText))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -295,7 +295,6 @@ class LibraryUpdateService(
                                 }
 
                                 currentlyUpdatingManga.add(manga)
-                                progressCount.andIncrement
                                 notifier.showProgressNotification(
                                     currentlyUpdatingManga,
                                     progressCount.get(),
@@ -328,6 +327,7 @@ class LibraryUpdateService(
                                 }
 
                                 currentlyUpdatingManga.remove(manga)
+                                progressCount.andIncrement
                                 notifier.showProgressNotification(
                                     currentlyUpdatingManga,
                                     progressCount.get(),


### PR DESCRIPTION
1. Make it easier to differentiate Manga Titles.
2.  Don't include updating manga to progress counter.