### PR TITLE
Added "Ninomae" theme

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -26,6 +26,7 @@ object PreferenceValues {
         BLUE(R.string.theme_blue),
         GREEN_APPLE(R.string.theme_greenapple),
         MIDNIGHT_DUSK(R.string.theme_midnightdusk),
+        NINOMAE(R.string.theme_ninomae),
         STRAWBERRY_DAIQUIRI(R.string.theme_strawberrydaiquiri),
         YOTSUBA(R.string.theme_yotsuba),
         YINYANG(R.string.theme_yinyang),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
@@ -50,6 +50,9 @@ abstract class BaseThemedActivity : AppCompatActivity() {
                 PreferenceValues.AppTheme.MIDNIGHT_DUSK -> {
                     resIds += R.style.Theme_Tachiyomi_MidnightDusk
                 }
+                PreferenceValues.AppTheme.NINOMAE -> {
+                    resIds += R.style.Theme_Tachiyomi_Ninomae
+                }
                 PreferenceValues.AppTheme.STRAWBERRY_DAIQUIRI -> {
                     resIds += R.style.Theme_Tachiyomi_StrawberryDaiquiri
                 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -14,6 +14,15 @@
     <color name="color_on_primary_greenapple">@color/md_black_1000</color>
     <color name="ripple_colored_greenapple">#1F48E484</color>
 
+    <!-- Ninomae Theme -->
+    <color name="accent_ninomae">#7C7693</color>
+    <color name="color_on_primary_ninomae">@color/md_white_1000</color>
+    <color name="tertiary_ninomae">#F3B375</color>
+    <color name="color_on_tertiary_ninomae">@color/md_black_1000</color>
+    <color name="ripple_colored_ninomae">#1F7C7693</color>
+    <color name="surface_ninomae">#252529</color>
+    <color name="background_ninomae">#252529</color>
+
     <!-- Yin Yang Theme -->
     <color name="accent_yinyang">#FFFFFF</color>
     <color name="color_on_secondary_yinyang">#000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,15 @@
     <color name="color_on_primary_greenapple">@color/md_white_1000</color>
     <color name="ripple_colored_greenapple">#1F188140</color>
 
+    <!-- Ninomae Theme -->
+    <color name="accent_ninomae">#66577E</color>
+    <color name="color_on_primary_ninomae">@color/md_white_1000</color>
+    <color name="tertiary_ninomae">#F3B375</color>
+    <color name="color_on_tertiary_ninomae">@color/md_black_1000</color>
+    <color name="ripple_colored_ninomae">#1F66577E</color>
+    <color name="surface_ninomae">#F3EDFF</color>
+    <color name="background_ninomae">#E0D7EE</color>
+
     <!-- Yin Yang Theme -->
     <color name="accent_yinyang">#000000</color>
     <color name="color_on_secondary_yinyang">#FFFFFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,7 @@
     <string name="theme_yotsuba">Yotsuba</string>
     <string name="theme_blue">Blue</string>
     <string name="theme_greenapple">Green Apple</string>
+    <string name="theme_ninomae">Ninomae</string>
     <string name="theme_yinyang">Yin &amp; Yang</string>
     <string name="theme_midnightdusk">Midnight Dusk</string>
     <string name="pref_dark_theme_pure_black">Pure black dark mode</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -113,6 +113,18 @@
         <item name="lightSystemBarsOnPrimary">true</item>
     </style>
 
+    <!--== Ninomae theme ==-->
+    <style name="Theme.Tachiyomi.Ninomae">
+        <!-- Theme colors -->
+        <item name="colorPrimary">@color/accent_ninomae</item>
+        <item name="colorOnPrimary">@color/color_on_primary_ninomae</item>
+        <item name="colorTertiary">@color/tertiary_ninomae</item>
+        <item name="colorOnTertiary">@color/color_on_tertiary_ninomae</item>
+        <item name="colorControlHighlight">@color/ripple_colored_ninomae</item>
+        <item name="colorSurface">@color/surface_ninomae</item>
+        <item name="android:colorBackground">@color/background_ninomae</item>
+    </style>
+
     <!--== Yin Yang theme ==-->
     <style name="Theme.Tachiyomi.YinYang">
         <!-- Theme colors -->


### PR DESCRIPTION
# UNFINISHED

Needs to be looked over by others, also might need to fix contrast, in dark theme might need to fix elevation to toolbar and bottom navigation. Look at AMOLED?

Discord feedback so far:
Light be lighter
Dark be darker
Dark more purple?

-------------

Based on the lovely Ninomae Ina'nis, for @arkon and @Flat. 

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- All base modes.

## Comparisons
Compared using the Yotsuba  theme, which was one of the low contrast ones.
| Light | Dark |
| ------------- | ----------- |
| ![Light](https://user-images.githubusercontent.com/10836780/125515730-ab817642-fe35-48aa-82f1-17891991ccf1.png) | ![Dark](https://user-images.githubusercontent.com/10836780/125515739-b40fc02b-932c-4636-aad7-1ef0d4dc0a9c.png) |
