### PR TITLE
Filter source manga by unread status

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -64,6 +64,11 @@ interface MangaQueries : DbProvider {
         )
         .prepare()
 
+    fun getMangaUnread(id: Long) = db.get()
+        .cursor()
+        .withQuery(RawQuery.builder().query(mangaUnreadQuery).args(id).build())
+        .prepare()
+
     fun insertManga(manga: Manga) = db.put().`object`(manga).prepare()
 
     fun insertMangas(mangas: List<Manga>) = db.put().objects(mangas).prepare()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -32,6 +32,22 @@ val libraryQuery =
 """
 
 /**
+ * Query to get the number of unread chapters for a manga, -1 if no chapters have been loaded yet.
+ */
+const val mangaUnreadQuery =
+    """
+    SELECT COALESCE(C.unread, -1) AS ${Manga.COL_UNREAD}
+    FROM ${Manga.TABLE}
+    LEFT JOIN (
+        SELECT ${Chapter.COL_MANGA_ID}, COUNT(CASE WHEN ${Chapter.COL_READ} = 0 THEN 1 END) AS unread
+        FROM ${Chapter.TABLE}
+        GROUP BY ${Chapter.COL_MANGA_ID}
+    ) AS C
+    ON ${Manga.COL_ID} = C.${Chapter.COL_MANGA_ID}
+    WHERE ${Manga.COL_ID} = ?
+"""
+
+/**
  * Query to get the recent chapters of manga from the library up to a date.
  */
 fun getRecentsQuery() =


### PR DESCRIPTION
Adds an option to all source filter sheets to filter based upon the unread chapters in the same way as the library filter.

I pulled out a `StandardFilter` interface which should make adding the other library filters pretty easy, but I wasn't interested in those so I only implemented unread. Since the way the unread count is loaded in the library (custom data model class) wasn't easy to re-use, I just created a new basic query. I also needed to distinguish the case of chapters not being loaded into the Chapter table yet vs. having no unread chapters, and this way I don't risk breaking the existing library code. I didn't bother with an `observeChanges*` call because the StorIO documentation is completely unclear on what it does exactly, and I don't believe it buys anything when just doing `executeAsBlocking()` calls.

Repaging is necessary so that the completely filtered pages get handled by the controller properly. Rather than doing some complicated work using `Pager` I just did the simplest thing.

UI-wise the new filter is just stuck at the top of all source filter sheets, using the same GUI as in the Library.

I'm an experienced Java dev but this is my first Kotlin work, so some stuff might not be idiomatic.