### PR TITLE
Make incognito bar use primary colors

### DIFF
--- a/app/src/main/res/layout-sw720dp/main_activity.xml
+++ b/app/src/main/res/layout-sw720dp/main_activity.xml
@@ -52,7 +52,7 @@
             android:id="@+id/incognito_mode"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="?attr/incognitoBackgroundColor"
+            android:background="?attr/colorPrimary"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -65,7 +65,7 @@
                 android:layout_gravity="center"
                 android:padding="4dp"
                 android:text="@string/pref_incognito_mode"
-                android:textColor="@color/md_white_1000" />
+                android:textColor="?attr/colorOnPrimary" />
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -47,7 +47,7 @@
             android:id="@+id/incognito_mode"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/incognitoBackgroundColor"
+            android:background="?attr/colorPrimary"
             android:visibility="gone"
             tools:visibility="visible">
 
@@ -57,7 +57,7 @@
                 android:layout_gravity="center"
                 android:padding="4dp"
                 android:text="@string/pref_incognito_mode"
-                android:textColor="@color/md_white_1000" />
+                android:textColor="?attr/colorOnPrimary" />
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/main_activity_toolbar.xml
+++ b/app/src/main/res/layout/main_activity_toolbar.xml
@@ -40,7 +40,7 @@
         android:id="@+id/incognito_mode"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/incognitoBackgroundColor"
+        android:background="?attr/colorPrimary"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -50,7 +50,7 @@
             android:layout_gravity="center"
             android:padding="4dp"
             android:text="@string/pref_incognito_mode"
-            android:textColor="@color/md_white_1000" />
+            android:textColor="?attr/colorOnPrimary" />
 
     </FrameLayout>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -22,7 +22,6 @@
     <color name="ripple_colored_tako">#1FF3B375</color>
     <color name="surface_tako">#2A2A3C</color>
     <color name="background_tako">#21212E</color>
-    <color name="incognito_background_tako">#17171C</color>
     <color name="filter_tako">@color/accent_tako</color>
 
     <!-- Yin & Yang Theme -->

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -32,9 +32,6 @@
 
     <attr name="lightSystemBarsOnPrimary" format="reference|boolean"/>
 
-    <!-- Custom color for incognito mode bar -->
-    <attr name="incognitoBackgroundColor" format="reference|integer"/>
-
     <!-- Setting chip color values for specific themes -->
     <attr name="chipTextColor" format="reference|integer"/>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -36,7 +36,6 @@
     <color name="ripple_colored_tako">#1F66577E</color>
     <color name="surface_tako">#F7F5FF</color>
     <color name="background_tako">#F2EDF7</color>
-    <color name="incognito_background_tako">@color/accent_tako</color>
     <color name="filter_tako">#F29940</color>
 
     <!-- Yin & Yang Theme -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -53,7 +53,6 @@
         <item name="toolbarNavigationButtonStyle">@style/Widget.Tachiyomi.Toolbar.Button.Navigation</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.Tachiyomi.BottomSheetDialog</item>
-        <item name="incognitoBackgroundColor">@color/md_grey_800</item>
         <item name="chipStyle">@style/Widget.Tachiyomi.Chip.Action</item>
         <item name="chipTextColor">?android:attr/textColorPrimary</item>
         <item name="chipBackgroundColor">?attr/colorControlHighlight</item>
@@ -118,9 +117,6 @@
         <item name="colorControlHighlight">@color/ripple_colored_tako</item>
         <item name="colorSurface">@color/surface_tako</item>
         <item name="android:colorBackground">@color/background_tako</item>
-
-        <!-- Themes -->
-        <item name="incognitoBackgroundColor">@color/incognito_background_tako</item>
 
         <!-- Custom Attributes-->
         <item name="colorFilterActive">@color/filter_tako</item>


### PR DESCRIPTION
Looks better than the odd forced gray used for all themes

## Tested
- **Android 10** emulator with **Pixel 5** preset.
- All themes in **Light**, **Dark** and **AMOLED** modes.
