### PR TITLE
Fix splash screen icon on Android 12

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.0-beta02")
     implementation("androidx.coordinatorlayout:coordinatorlayout:1.1.0")
     implementation("androidx.core:core-ktx:1.7.0-alpha01")
+    implementation("androidx.core:core-splashscreen:1.0.0-alpha01")
     implementation("androidx.multidex:multidex:2.0.1")
     implementation("androidx.preference:preference-ktx:1.1.1")
     implementation("androidx.recyclerview:recyclerview:1.2.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:launchMode="singleTop"
-            android:theme="@style/Theme.Splash">
+            android:theme="@style/Theme.Tachiyomi.SplashScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
@@ -31,6 +31,8 @@ import eu.kanade.tachiyomi.ui.browse.BrowseController
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceController
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchController
 import eu.kanade.tachiyomi.ui.browse.source.latest.LatestUpdatesController
+import eu.kanade.tachiyomi.ui.main.MainActivity
+import eu.kanade.tachiyomi.util.view.onAnimationsFinished
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -81,6 +83,9 @@ class SourceController :
         // Create recycler and set adapter.
         binding.recycler.layoutManager = LinearLayoutManager(view.context)
         binding.recycler.adapter = adapter
+        binding.recycler.onAnimationsFinished {
+            (activity as? MainActivity)?.ready = true
+        }
         adapter?.fastScroller = binding.fastScroller
 
         requestPermissionsSafe(arrayOf(WRITE_EXTERNAL_STORAGE), 301)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
@@ -14,9 +14,11 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.databinding.LibraryCategoryBinding
+import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.lang.plusAssign
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.inflate
+import eu.kanade.tachiyomi.util.view.onAnimationsFinished
 import eu.kanade.tachiyomi.widget.AutofitRecyclerView
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -105,6 +107,10 @@ class LibraryCategoryView @JvmOverloads constructor(context: Context, attrs: Att
                 binding.swipeRefresh.isEnabled = firstPos <= 0
             }
             .launchIn(scope)
+
+        recycler.onAnimationsFinished {
+            (controller.activity as? MainActivity)?.ready = true
+        }
 
         // Double the distance required to trigger sync
         binding.swipeRefresh.setDistanceToTriggerSync((2 * 64 * resources.displayMetrics.density).toInt())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -277,6 +277,7 @@ class LibraryController(
             binding.emptyView.hide()
         } else {
             binding.emptyView.show(R.string.information_empty_library)
+            (activity as? MainActivity)?.ready = true
         }
 
         // Get the current active category.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -94,17 +94,7 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Prevent splash screen showing up on configuration changes
-        val splashScreen = if (savedInstanceState == null) {
-            installSplashScreen().apply {
-                val startTime = System.currentTimeMillis()
-                setKeepVisibleCondition {
-                    val elapsed = System.currentTimeMillis() - startTime
-                    elapsed <= SPLASH_MIN_DURATION || (!ready && elapsed <= SPLASH_MAX_DURATION)
-                }
-            }
-        } else {
-            null
-        }
+        val splashScreen = if (savedInstanceState == null) installSplashScreen() else null
 
         super.onCreate(savedInstanceState)
 
@@ -139,6 +129,11 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
             }
         }
 
+        val startTime = System.currentTimeMillis()
+        splashScreen?.setKeepVisibleCondition {
+            val elapsed = System.currentTimeMillis() - startTime
+            elapsed <= SPLASH_MIN_DURATION || (!ready && elapsed <= SPLASH_MAX_DURATION)
+        }
         setSplashScreenExitAnimation(splashScreen)
 
         tabAnimator = ViewHeightAnimator(binding.tabs, 0L)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -81,6 +82,11 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
     private var fixedViewsToBottom = mutableMapOf<View, AppBarLayout.OnOffsetChangedListener>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Prevent splash screen showing up on configuration changes
+        if (savedInstanceState == null) {
+            installSplashScreen()
+        }
+
         super.onCreate(savedInstanceState)
 
         val didMigration = if (savedInstanceState == null) Migrations.upgrade(preferences) else false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -81,10 +81,18 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
 
     private var fixedViewsToBottom = mutableMapOf<View, AppBarLayout.OnOffsetChangedListener>()
 
+    // To be checked by splash screen. If true then splash screen will be removed.
+    var ready = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         // Prevent splash screen showing up on configuration changes
         if (savedInstanceState == null) {
-            installSplashScreen()
+            installSplashScreen().also {
+                val startedTime = System.currentTimeMillis()
+                it.setKeepVisibleCondition {
+                    !ready && System.currentTimeMillis() - startedTime < 5000
+                }
+            }
         }
 
         super.onCreate(savedInstanceState)
@@ -361,6 +369,7 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
             }
         }
 
+        ready = true
         isHandlingShortcut = false
         return true
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -96,9 +96,10 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
         // Prevent splash screen showing up on configuration changes
         val splashScreen = if (savedInstanceState == null) {
             installSplashScreen().apply {
-                val startedTime = System.currentTimeMillis()
+                val startTime = System.currentTimeMillis()
                 setKeepVisibleCondition {
-                    !ready && System.currentTimeMillis() - startedTime < 5000
+                    val elapsed = System.currentTimeMillis() - startTime
+                    elapsed <= SPLASH_MIN_DURATION || (!ready && elapsed <= SPLASH_MAX_DURATION)
                 }
             }
         } else {
@@ -310,7 +311,7 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
 
                 val activityAnim = ValueAnimator.ofFloat(1F, 0F).apply {
                     interpolator = LinearOutSlowInInterpolator()
-                    duration = 400L
+                    duration = SPLASH_EXIT_ANIM_DURATION
                     addUpdateListener { va ->
                         val value = va.animatedValue as Float
                         binding.root.translationY = value * 16.dpToPx
@@ -320,7 +321,7 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
                 var barColorRestored = false
                 val splashAnim = ValueAnimator.ofFloat(1F, 0F).apply {
                     interpolator = FastOutSlowInInterpolator()
-                    duration = 400L
+                    duration = SPLASH_EXIT_ANIM_DURATION
                     addUpdateListener { va ->
                         val value = va.animatedValue as Float
                         splashProvider.view.alpha = value
@@ -618,6 +619,11 @@ class MainActivity : BaseViewBindingActivity<MainActivityBinding>() {
         get() = binding.bottomNav ?: binding.sideNav!!
 
     companion object {
+        // Splash screen
+        private const val SPLASH_MIN_DURATION = 500 // ms
+        private const val SPLASH_MAX_DURATION = 5000 // ms
+        private const val SPLASH_EXIT_ANIM_DURATION = 400L // ms
+
         // Shortcut actions
         const val SHORTCUT_LIBRARY = "eu.kanade.tachiyomi.SHOW_LIBRARY"
         const val SHORTCUT_RECENTLY_UPDATED = "eu.kanade.tachiyomi.SHOW_RECENTLY_UPDATED"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
@@ -23,9 +23,11 @@ import eu.kanade.tachiyomi.ui.base.controller.NucleusController
 import eu.kanade.tachiyomi.ui.base.controller.RootController
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
 import eu.kanade.tachiyomi.ui.browse.source.browse.ProgressItem
+import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaController
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.view.onAnimationsFinished
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -109,6 +111,9 @@ class HistoryController :
             adapter?.updateDataSet(mangaHistory)
         } else {
             adapter?.onLoadMoreComplete(mangaHistory)
+        }
+        binding.recycler.onAnimationsFinished {
+            (activity as? MainActivity)?.ready = true
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesController.kt
@@ -27,6 +27,7 @@ import eu.kanade.tachiyomi.ui.manga.chapter.base.BaseChaptersAdapter
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.view.onAnimationsFinished
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import reactivecircus.flowbinding.recyclerview.scrollStateChanges
@@ -224,6 +225,9 @@ class UpdatesController :
     fun onNextRecentChapters(chapters: List<IFlexible<*>>) {
         destroyActionModeIfNeeded()
         adapter?.updateDataSet(chapters)
+        binding.recycler.onAnimationsFinished {
+            (activity as? MainActivity)?.ready = true
+        }
     }
 
     override fun onUpdateEmptyView(size: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/view/ViewExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/view/ViewExtensions.kt
@@ -197,3 +197,20 @@ inline fun TextView.setMaxLinesAndEllipsize(_ellipsize: TextUtils.TruncateAt = T
     maxLines = (measuredHeight - paddingTop - paddingBottom) / lineHeight
     ellipsize = _ellipsize
 }
+
+/**
+ * Callback will be run immediately when no animation running
+ */
+fun RecyclerView.onAnimationsFinished(callback: (RecyclerView) -> Unit) = post(
+    object : Runnable {
+        override fun run() {
+            if (isAnimating) {
+                itemAnimator?.isRunning {
+                    post(this)
+                }
+            } else {
+                callback(this@onAnimationsFinished)
+            }
+        }
+    }
+)

--- a/app/src/main/res/drawable/ic_tachi_splash.xml
+++ b/app/src/main/res/drawable/ic_tachi_splash.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:drawable="@color/splash" />
-
     <item
         android:width="72dp"
         android:height="72dp"
         android:drawable="@drawable/ic_tachi"
         android:gravity="center" />
-
 </layer-list>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -178,8 +178,10 @@
     <!--===============-->
 
     <!--== Splash Theme ==-->
-    <style name="Theme.Splash" parent="Theme.Tachiyomi">
-        <item name="android:windowBackground">@drawable/splash_background</item>
+    <style name="Theme.Tachiyomi.SplashScreen" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_tachi_splash</item>
+        <item name="windowSplashScreenBackground">@color/splash</item>
+        <item name="postSplashScreenTheme">@style/Theme.Tachiyomi</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>


### PR DESCRIPTION
This also adds splash screen exit animation on older android version which replicates the animation in Android 12 (I've tried).

The splash screen will be removed after all items inside starting screen is finished showing, also has timeout just in case.

=Previews=
[Android 10](https://user-images.githubusercontent.com/12537387/126042351-bfeaf480-98a2-456e-9a7b-93a8f68cd329.mp4)
[Android 12](https://user-images.githubusercontent.com/12537387/126042456-8e594109-d785-4f4e-a977-f5256c5eecef.mp4)


