### PR TITLE
Make default tracking status depend if the user has read chapter or not

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
@@ -36,6 +36,10 @@ abstract class TrackService(val id: Int) {
 
     abstract fun getStatus(status: Int): String
 
+    abstract fun getReadingStatus(): Int
+
+    abstract fun getRereadingStatus(): Int
+
     abstract fun getCompletionStatus(): Int
 
     abstract fun getScoreList(): List<String>
@@ -46,9 +50,9 @@ abstract class TrackService(val id: Int) {
 
     abstract fun displayScore(track: Track): String
 
-    abstract suspend fun update(track: Track): Track
+    abstract suspend fun update(track: Track, didReadChapter: Boolean = false): Track
 
-    abstract suspend fun bind(track: Track): Track
+    abstract suspend fun bind(track: Track, hasReadChapters: Boolean = false): Track
 
     abstract suspend fun search(query: String): List<TrackSearch>
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
@@ -49,17 +49,27 @@ class Komga(private val context: Context, id: Int) : TrackService(id), Unattende
         }
     }
 
+    override fun getReadingStatus(): Int = READING
+
+    override fun getRereadingStatus(): Int = -1
+
     override fun getCompletionStatus(): Int = COMPLETED
 
     override fun getScoreList(): List<String> = emptyList()
 
     override fun displayScore(track: Track): String = ""
 
-    override suspend fun update(track: Track): Track {
+    override suspend fun update(track: Track, didReadChapter: Boolean): Track {
+        if (track.status != COMPLETED) {
+            if (didReadChapter) {
+                track.status = READING
+            }
+        }
+
         return api.updateProgress(track)
     }
 
-    override suspend fun bind(track: Track): Track {
+    override suspend fun bind(track: Track, hasReadChapters: Boolean): Track {
         return track
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
@@ -44,19 +44,31 @@ class Shikimori(private val context: Context, id: Int) : TrackService(id) {
         return api.addLibManga(track, getUsername())
     }
 
-    override suspend fun update(track: Track): Track {
+    override suspend fun update(track: Track, didReadChapter: Boolean): Track {
+        if (track.status != COMPLETED) {
+            if (track.status != REPEATING && didReadChapter) {
+                track.status = READING
+            }
+        }
+
         return api.updateLibManga(track, getUsername())
     }
 
-    override suspend fun bind(track: Track): Track {
+    override suspend fun bind(track: Track, hasReadChapters: Boolean): Track {
         val remoteTrack = api.findLibManga(track, getUsername())
         return if (remoteTrack != null) {
             track.copyPersonalFrom(remoteTrack)
             track.library_id = remoteTrack.library_id
+
+            if (track.status != COMPLETED) {
+                val isRereading = track.status == REPEATING
+                track.status = if (isRereading.not() && hasReadChapters) READING else track.status
+            }
+
             update(track)
         } else {
             // Set default fields if it's not found in the list
-            track.status = READING
+            track.status = if (hasReadChapters) READING else PLANNING
             track.score = 0F
             add(track)
         }
@@ -93,6 +105,10 @@ class Shikimori(private val context: Context, id: Int) : TrackService(id) {
             else -> ""
         }
     }
+
+    override fun getReadingStatus(): Int = READING
+
+    override fun getRereadingStatus(): Int = REPEATING
 
     override fun getCompletionStatus(): Int = COMPLETED
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -779,7 +779,8 @@ class MangaPresenter(
             item.manga_id = manga.id!!
             launchIO {
                 try {
-                    service.bind(item)
+                    val hasReadChapters = allChapters.any { it.read }
+                    service.bind(item, hasReadChapters)
                     db.insertTrack(item).executeAsBlocking()
 
                     if (service is UnattendedTrackService) {
@@ -830,6 +831,9 @@ class MangaPresenter(
 
     fun setTrackerLastChapterRead(item: TrackItem, chapterNumber: Int) {
         val track = item.track!!
+        if (track.last_chapter_read == 0 && track.last_chapter_read < chapterNumber && track.status != item.service.getRereadingStatus()) {
+            track.status = item.service.getReadingStatus()
+        }
         track.last_chapter_read = chapterNumber
         if (track.total_chapters != 0 && track.last_chapter_read == track.total_chapters) {
             track.status = item.service.getCompletionStatus()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -713,7 +713,7 @@ class ReaderPresenter(
                         // for a while. The view can still be garbage collected.
                         async {
                             runCatching {
-                                service.update(track)
+                                service.update(track, true)
                                 db.insertTrack(track).executeAsBlocking()
                             }
                         }


### PR DESCRIPTION
closes #200

This makes so tracking status changes depending on if a user has read chapter(s) for a manga when adding a new tracker to it.
- If a user hasn't read any it will make the tracking status plan to read
- If a user read one or more it will make the tracking status reading
- When a user changes chapter number from 0 it will change tracking status to reading
    - It will not change when changing between e.g. 5 -> 10 or 41 -> 10

When a user reads a chapter it will also change to status to reading

For trackers that have rereading as status, it will leave it as is 
