### PR TITLE
Add Dynamic theme for Android 12

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -23,6 +23,7 @@ object PreferenceValues {
 
     enum class AppTheme(val titleResId: Int?) {
         DEFAULT(R.string.theme_default),
+        MONET(R.string.theme_monet),
         BLUE(R.string.theme_blue),
         GREEN_APPLE(R.string.theme_greenapple),
         MIDNIGHT_DUSK(R.string.theme_midnightdusk),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseThemedActivity.kt
@@ -40,6 +40,9 @@ abstract class BaseThemedActivity : AppCompatActivity() {
         fun AppCompatActivity.applyThemePreferences(preferences: PreferencesHelper) {
             val resIds = mutableListOf<Int>()
             when (preferences.appTheme().get()) {
+                PreferenceValues.AppTheme.MONET -> {
+                    resIds += R.style.Theme_Tachiyomi_Monet
+                }
                 PreferenceValues.AppTheme.BLUE -> {
                     resIds += R.style.Theme_Tachiyomi_Blue
                     resIds += R.style.ThemeOverlay_Tachiyomi_ColoredBars

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -122,7 +122,14 @@ class SettingsGeneralController : SettingsController() {
                 key = Keys.appTheme
                 titleRes = R.string.pref_app_theme
 
-                val appThemes = Values.AppTheme.values().filter { it.titleResId != null }
+                val appThemes = Values.AppTheme.values().filter {
+                    val monetFilter = if (it == Values.AppTheme.MONET) {
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                    } else {
+                        true
+                    }
+                    it.titleResId != null && monetFilter
+                }
                 entriesRes = appThemes.map { it.titleResId!! }.toTypedArray()
                 entryValues = appThemes.map { it.name }.toTypedArray()
                 defaultValue = appThemes[0].name

--- a/app/src/main/res/color-night-v31/text_primary_monet.xml
+++ b/app/src/main/res/color-night-v31/text_primary_monet.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@android:color/system_neutral1_500" android:state_enabled="false" />
+    <item android:color="@android:color/system_neutral1_50" />
+</selector>

--- a/app/src/main/res/color-night-v31/text_secondary_monet.xml
+++ b/app/src/main/res/color-night-v31/text_secondary_monet.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="?android:attr/disabledAlpha" android:color="@android:color/system_neutral2_200" android:state_enabled="false" />
+    <item android:color="@android:color/system_neutral2_200" />
+</selector>

--- a/app/src/main/res/color-v31/ripple_colored_monet.xml
+++ b/app/src/main/res/color-v31/ripple_colored_monet.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/accent_monet" android:alpha="0.12" />
+</selector>

--- a/app/src/main/res/color-v31/text_primary_monet.xml
+++ b/app/src/main/res/color-v31/text_primary_monet.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@android:color/system_neutral1_400" android:state_enabled="false" />
+    <item android:color="@android:color/system_neutral1_900" />
+</selector>

--- a/app/src/main/res/color-v31/text_secondary_monet.xml
+++ b/app/src/main/res/color-v31/text_secondary_monet.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="?android:attr/disabledAlpha" android:color="@android:color/system_neutral2_700" android:state_enabled="false" />
+    <item android:color="@android:color/system_neutral2_700" />
+</selector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <color name="splash">@color/background_default</color>
 
     <!-- Default Theme -->
@@ -8,6 +8,15 @@
     <color name="surface_default">#242529</color>
     <color name="background_default">#202125</color>
     <color name="ripple_colored_default">#1F3399FF</color>
+
+    <!-- Monet Theme -->
+    <color name="accent_monet" tools:targetApi="31">@android:color/system_accent1_100</color>
+    <color name="on_accent_monet" tools:targetApi="31">@android:color/system_accent1_900</color>
+    <color name="divider_monet" tools:targetApi="31">@android:color/system_neutral1_700</color>
+    <color name="tertiary_monet" tools:targetApi="31">@android:color/system_accent3_100</color>
+    <color name="on_tertiary_monet" tools:targetApi="31">@android:color/system_accent3_900</color>
+    <color name="surface_monet" tools:targetApi="31">@android:color/system_neutral1_900</color>
+    <color name="on_surface_monet" tools:targetApi="31">@android:color/system_neutral1_50</color>
 
     <!-- Green Apple Theme -->
     <color name="accent_greenapple">#48E484</color>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Tachiyomi.Monet">
+        <item name="colorPrimary">@color/accent_monet</item>
+        <item name="colorOnPrimary">@color/on_accent_monet</item>
+        <item name="colorTertiary">@color/tertiary_monet</item>
+        <item name="colorOnTertiary">@color/on_tertiary_monet</item>
+        <item name="colorSurface">@color/surface_monet</item>
+        <item name="colorOnSurface">@color/on_surface_monet</item>
+        <item name="android:colorBackground">@color/background_monet</item>
+        <item name="colorOnBackground">@color/on_background_monet</item>
+        <item name="colorControlHighlight">@color/ripple_colored_monet</item>
+        <item name="android:divider">@color/divider_monet</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -11,5 +11,7 @@
         <item name="colorOnBackground">@color/on_background_monet</item>
         <item name="colorControlHighlight">@color/ripple_colored_monet</item>
         <item name="android:divider">@color/divider_monet</item>
+        <item name="android:textColorPrimary">@color/text_primary_monet</item>
+        <item name="android:textColorSecondary">@color/text_secondary_monet</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <color name="splash">@color/accent_blue</color>
 
     <!-- Default Theme -->
@@ -8,6 +8,17 @@
     <color name="surface_default">@color/md_white_1000</color>
     <color name="background_default">@color/md_grey_50</color>
     <color name="ripple_colored_default">@color/md_blue_A400_12</color>
+
+    <!-- Monet Theme -->
+    <color name="accent_monet" tools:targetApi="31">@android:color/system_accent1_600</color>
+    <color name="on_accent_monet" tools:targetApi="31">@android:color/system_accent1_10</color>
+    <color name="divider_monet" tools:targetApi="31">@android:color/system_neutral1_200</color>
+    <color name="tertiary_monet" tools:targetApi="31">@android:color/system_accent3_600</color>
+    <color name="on_tertiary_monet" tools:targetApi="31">@android:color/system_accent3_10</color>
+    <color name="surface_monet" tools:targetApi="31">@android:color/system_neutral1_50</color>
+    <color name="on_surface_monet" tools:targetApi="31">@android:color/system_neutral1_900</color>
+    <color name="background_monet" tools:targetApi="31">@color/surface_monet</color>
+    <color name="on_background_monet" tools:targetApi="31">@color/on_surface_monet</color>
 
     <!-- Blue Theme -->
     <color name="accent_blue">#54759E</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="theme_dark">On</string>
     <string name="pref_app_theme">App theme</string>
     <string name="theme_default">Default</string>
+    <string name="theme_monet">Dynamic</string>
     <string name="theme_blue">Blue</string>
     <string name="theme_greenapple">Green Apple</string>
     <string name="theme_midnightdusk">Midnight Dusk</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -74,6 +74,9 @@
     <!--== Default Theme ==-->
     <style name="Theme.Tachiyomi" parent="Base.Theme.Tachiyomi" />
 
+    <!-- Monet theme only support S+ -->
+    <style name="Theme.Tachiyomi.Monet" />
+
     <!--== Blue Theme ==-->
     <style name="Theme.Tachiyomi.Blue">
         <!-- Theme Colors -->


### PR DESCRIPTION
Followed AOSP's DeviceDefault theme except on surface color because it breaks all dialogs.

| Light | Dark |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/12537387/126055114-3bc66445-57f4-4475-befd-6c43899c81eb.png) | ![image](https://user-images.githubusercontent.com/12537387/126055132-c17a7f12-dad7-499e-be13-fb51e8604472.png) |
| ![image](https://user-images.githubusercontent.com/12537387/126055084-62e189e0-0277-4a3f-a7f9-72a5cb0ba8b8.png) | ![image](https://user-images.githubusercontent.com/12537387/126055075-34c16cbe-48fa-4869-ba39-fe48e0aa3f76.png) |
| ![image](https://user-images.githubusercontent.com/12537387/126055162-49058687-5a05-4fbd-895a-75d25495a834.png) | ![image](https://user-images.githubusercontent.com/12537387/126055155-c18f4666-263d-44f8-a4a8-ec37eef6b8a4.png) |

