### PR TITLE
Auto hide reader menu when user starts reading again

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.reader
 
 import android.annotation.SuppressLint
 import android.annotation.TargetApi
+import android.app.ActionBar
 import android.app.ProgressDialog
 import android.content.ClipData
 import android.content.Context
@@ -189,6 +190,7 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
         readingModeToast?.cancel()
         progressDialog?.dismiss()
         progressDialog = null
+        listeners = mutableListOf()
     }
 
     /**
@@ -486,12 +488,23 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
         )
     }
 
+    private var listeners: MutableList<ActionBar.OnMenuVisibilityListener> = mutableListOf()
+
+    fun addOnMenuVisibilityListener(listener: ActionBar.OnMenuVisibilityListener) {
+        listeners.add(listener)
+    }
+
+    fun removeOnMenuVisibilityListener(listener: ActionBar.OnMenuVisibilityListener) {
+        listeners.remove(listener)
+    }
+
     /**
      * Sets the visibility of the menu according to [visible] and with an optional parameter to
      * [animate] the views.
      */
     fun setMenuVisibility(visible: Boolean, animate: Boolean = true) {
         menuVisible = visible
+        listeners.forEach { listener -> listener.onMenuVisibilityChanged(visible) }
         if (visible) {
             windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
             binding.readerMenu.isVisible = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -738,6 +738,15 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
     }
 
     /**
+     * Called from the viewer to hide the menu.
+     */
+    fun hideMenu() {
+        if (menuVisible) {
+            setMenuVisibility(false)
+        }
+    }
+
+    /**
      * Called from the page sheet. It delegates the call to the presenter to do some IO, which
      * will call [onShareImageResult] with the path the image was saved on when it's ready.
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.pager
 
 import android.annotation.SuppressLint
+import android.app.ActionBar
 import android.graphics.PointF
 import android.graphics.drawable.Animatable
 import android.view.GestureDetector
@@ -94,9 +95,28 @@ class PagerPageHolder(
      */
     private var readImageHeaderSubscription: Subscription? = null
 
+    private var visibilityListener = ActionBar.OnMenuVisibilityListener { isVisible ->
+        if (isVisible.not()) {
+            subsamplingImageView?.setOnStateChangedListener(null)
+            return@OnMenuVisibilityListener
+        }
+        subsamplingImageView?.setOnStateChangedListener(
+            object : SubsamplingScaleImageView.OnStateChangedListener {
+                override fun onScaleChanged(newScale: Float, origin: Int) {
+                    viewer.activity.hideMenu()
+                }
+
+                override fun onCenterChanged(newCenter: PointF?, origin: Int) {
+                    viewer.activity.hideMenu()
+                }
+            }
+        )
+    }
+
     init {
         addView(progressBar)
         observeStatus()
+        viewer.activity.addOnMenuVisibilityListener(visibilityListener)
     }
 
     /**
@@ -110,6 +130,7 @@ class PagerPageHolder(
         unsubscribeReadImageHeader()
         subsamplingImageView?.setOnImageEventListener(null)
         subsamplingImageView?.setOnStateChangedListener(null)
+        viewer.activity.removeOnMenuVisibilityListener(visibilityListener)
     }
 
     /**
@@ -365,17 +386,6 @@ class PagerPageHolder(
 
                     override fun onImageLoadError(e: Exception) {
                         onImageDecodeError()
-                    }
-                }
-            )
-            setOnStateChangedListener(
-                object : SubsamplingScaleImageView.OnStateChangedListener {
-                    override fun onScaleChanged(newScale: Float, origin: Int) {
-                        viewer.activity.hideMenu()
-                    }
-
-                    override fun onCenterChanged(newCenter: PointF?, origin: Int) {
-                        viewer.activity.hideMenu()
                     }
                 }
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -109,6 +109,7 @@ class PagerPageHolder(
         unsubscribeStatus()
         unsubscribeReadImageHeader()
         subsamplingImageView?.setOnImageEventListener(null)
+        subsamplingImageView?.setOnStateChangedListener(null)
     }
 
     /**
@@ -364,6 +365,17 @@ class PagerPageHolder(
 
                     override fun onImageLoadError(e: Exception) {
                         onImageDecodeError()
+                    }
+                }
+            )
+            setOnStateChangedListener(
+                object : SubsamplingScaleImageView.OnStateChangedListener {
+                    override fun onScaleChanged(newScale: Float, origin: Int) {
+                        viewer.activity.hideMenu()
+                    }
+
+                    override fun onCenterChanged(newCenter: PointF?, origin: Int) {
+                        viewer.activity.hideMenu()
                     }
                 }
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -153,6 +153,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
      * Called when a new page (either a [ReaderPage] or [ChapterTransition]) is marked as active
      */
     private fun onPageChange(position: Int) {
+        activity.hideMenu()
         val page = adapter.items.getOrNull(position)
         if (page != null && currentPage != page) {
             val allowPreload = checkAllowPreload(page as? ReaderPage)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -243,6 +243,7 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
     }
 
     fun onScrolled(pos: Int? = null) {
+        activity.hideMenu()
         val position = pos ?: layoutManager.findLastEndVisibleItemPosition()
         val item = adapter.items.getOrNull(position)
         val allowPreload = checkAllowPreload(item as? ReaderPage)


### PR DESCRIPTION
closes #3411

This makes so the reader menu auto hides when changing page or scrolling to keep the user immersed in reading 
