### PR TITLE
For library update error log, group errors by error string, and then sort the resulting list by source

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -511,9 +511,19 @@ class LibraryUpdateService(
             if (errors.isNotEmpty()) {
                 val file = createFileInCacheDir("tachiyomi_update_errors.txt")
                 file.bufferedWriter().use { out ->
-                    errors.forEach { (manga, error) ->
-                        val source = sourceManager.getOrStub(manga.source)
-                        out.write("${manga.title} ($source): $error\n")
+                    // Error file format:
+                    // ! Error
+                    //   # Source
+                    //     - Manga
+                    errors.groupBy({ it.second }, { it.first }).forEach { (error, mangas) ->
+                        out.write("! ${error}\n")
+                        mangas.groupBy { it.source }.forEach { (srcId, mangas) ->
+                            val source = sourceManager.getOrStub(srcId)
+                            out.write("  # $source\n")
+                            mangas.forEach {
+                                out.write("    - ${it.title}\n")
+                            }
+                        }
                     }
                 }
                 return file


### PR DESCRIPTION
Format is e.g.
```
! Error 1
  # Source 1
    - Manga 1
! Error 2
  # Source 1
    - Manga 5
  # Source 2
    - Manga 2
    - Manga 3
  # Source 3
    - Manga 4
```