### PR TITLE
Group 'Source not installed' cases in library update error log

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -316,6 +316,9 @@ class LibraryUpdateService(
                                 } catch (e: Throwable) {
                                     val errorMessage = if (e is NoChaptersException) {
                                         getString(R.string.no_chapters_error)
+                                    } else if (e is SourceManager.SourceNotInstalledException) {
+                                        // failedUpdates will already have the source, don't need to copy it into the message
+                                        getString(R.string.loader_not_implemented_error)
                                     } else {
                                         e.message
                                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -70,8 +70,11 @@ open class SourceManager(private val context: Context) {
             return name
         }
 
-        private fun getSourceNotInstalledException(): Exception {
-            return Exception(context.getString(R.string.source_not_installed, id.toString()))
+        private fun getSourceNotInstalledException(): SourceNotInstalledException {
+            return SourceNotInstalledException(id)
         }
     }
+
+    inner class SourceNotInstalledException(val id: Long) :
+        Exception(context.getString(R.string.source_not_installed, id.toString()))
 }


### PR DESCRIPTION
Followup to #5586

Uses "Source not found" string for failedUpdates list.
Exception behaves as normal for other cases.