### PR TITLE
Revert changes to last_update behavior from #5436

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -13,8 +13,10 @@ interface Manga : SManga {
 
     var favorite: Boolean
 
+    // last time the chapter list changed in any way
     var last_update: Long
 
+    // predicted next update time based on latest (by date) 4 chapters' deltas
     var next_update: Long
 
     var date_added: Long

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -111,10 +111,6 @@ fun syncChaptersWithSource(
             db.updateNextUpdated(manga).executeAsBlocking()
         }
 
-        if (newestDate != 0L && newestDate != manga.last_update) {
-            manga.last_update = newestDate
-            db.updateLastUpdated(manga).executeAsBlocking()
-        }
         return Pair(emptyList(), emptyList())
     }
 
@@ -177,13 +173,8 @@ fun syncChaptersWithSource(
         db.fixChaptersSourceOrder(sourceChapters).executeAsBlocking()
 
         // Set this manga as updated since chapters were changed
-        val newestChapter = topChapters.getOrNull(0)
-        val dateFetch = newestChapter?.date_upload ?: manga.last_update
-        if (dateFetch == 0L) {
-            if (toAdd.isNotEmpty()) {
-                manga.last_update = Date().time
-            }
-        } else manga.last_update = dateFetch
+        // Note that last_update actually represents last time the chapter list changed at all
+        manga.last_update = Date().time
         db.updateLastUpdated(manga).executeAsBlocking()
     }
 


### PR DESCRIPTION
last_update is used for 2 things: "Last checked" sort, and "Latest first" update order.

Prior to next_update's impl, last_update recorded the last time the given manga's chapter list changed in any way (an "update" was an addition, removal, or rename/other change in the chapter list).

When #5436 next_update was implemented, last_update's behavior was changed to instead be whatever the latest chapter upload date was, which technically fits use case 2 ("Latest first" update order) but does not at all match use case 1 ("Last checked" sort).
The next_update impl itself makes no use of last_update, so this is reverting that behavior change.

Moving forward, it may be worth renaming this field to last_change to reflect what it does. Moreover, any new field for 'latest chapter upload date' would potentially be redundant as that information can be retrieved from the DB/chapter list already.

If "Latest first" update order needs to be changed to use the latest chapter upload date, that change should be made in LibraryUpdateRanker.latestFirstRanking() instead of modifying the behavior of last_update.