### PR TITLE
Remove unnecessary type guards to enable better tracker updating, addresses tracking offline reading concerns

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -492,9 +492,8 @@ class LibraryUpdateService(
                                 val updatedTrack = service.refresh(track)
                                 db.insertTrack(updatedTrack).executeAsBlocking()
 
-                                if (service is EnhancedTrackService) {
-                                    syncChaptersWithTrackServiceTwoWay(db, db.getChapters(manga).executeAsBlocking(), track, service)
-                                }
+                                syncChaptersWithTrackServiceTwoWay(db, db.getChapters(manga).executeAsBlocking(), track, service)
+
                             } catch (e: Throwable) {
                                 // Ignore errors and continue
                                 Timber.e(e)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -807,9 +807,8 @@ class MangaPresenter(
                                 val track = it.service.refresh(it.track!!)
                                 db.insertTrack(track).executeAsBlocking()
 
-                                if (it.service is EnhancedTrackService) {
-                                    syncChaptersWithTrackServiceTwoWay(db, allChapters, track, it.service)
-                                }
+                                syncChaptersWithTrackServiceTwoWay(db, allChapters, track, it.service)
+
                             }
                         }
                         .awaitAll()
@@ -843,9 +842,8 @@ class MangaPresenter(
                     service.bind(item, hasReadChapters)
                     db.insertTrack(item).executeAsBlocking()
 
-                    if (service is EnhancedTrackService) {
-                        syncChaptersWithTrackServiceTwoWay(db, allChapters, item, service)
-                    }
+                    syncChaptersWithTrackServiceTwoWay(db, allChapters, item, service)
+
                 } catch (e: Throwable) {
                     withUIContext { view?.applicationContext?.toast(e.message) }
                 }


### PR DESCRIPTION
Addresses #2905 and #2397.

Rather than doing something like queuing tracker changes when offline, being able to sync the library so that trackers are updated based on locally read chapters is even better.

This feature is basically already implemented, but there's some unnecessary checks going on that prevent it from actually working.

The in-app setting is:  
Settings => Library => Automatically update trackers

The `syncChapersWitTrackServiceTwoWay` method doesn't require an `EnhancedTrackService` parameter, so there's no reason to be guarding.

https://github.com/tachiyomiorg/tachiyomi/blob/ff2a4e69526a2edfa5f3bd7570c09204e5ebb9f9/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt#L10-L18



