### PR TITLE
Tracking: replace tick with button

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -63,7 +63,6 @@ class TrackSearchDialog : DialogController {
         binding = TrackSearchDialogBinding.inflate(LayoutInflater.from(activity!!))
 
         // Toolbar stuff
-        binding!!.toolbar.menu.findItem(R.id.done).setVisible(false)
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
         binding!!.trackBtn.setOnClickListener {
             val adapter = adapter ?: return@setOnClickListener

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -64,7 +64,6 @@ class TrackSearchDialog : DialogController {
 
         // Toolbar stuff
         binding!!.toolbar.menu.findItem(R.id.done).setVisible(false)
-        binding!!.trackBtn.isVisible = false
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
         binding!!.trackBtn.setOnClickListener {
             when (it.id) {
@@ -82,7 +81,7 @@ class TrackSearchDialog : DialogController {
         // Create adapter
         adapter = TrackSearchAdapter(currentTrackUrl) { which ->
             binding!!.trackBtn.isClickable = which != null
-            binding!!.trackBtn.isVisible = true
+            binding!!.trackBtn.isEnabled = true
         }
         binding!!.trackSearchRecyclerview.adapter = adapter
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -42,6 +42,8 @@ class TrackSearchDialog : DialogController {
 
     private lateinit var currentlySearched: String
 
+    private var menuItemOK = binding!!.toolbar.menu.findItem(R.id.done)
+
     constructor(
         target: MangaController,
         _service: TrackService,
@@ -64,6 +66,7 @@ class TrackSearchDialog : DialogController {
 
         // Toolbar stuff
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
+        menuItemOK.setVisible(false)
         binding!!.toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.done -> {
@@ -80,7 +83,8 @@ class TrackSearchDialog : DialogController {
 
         // Create adapter
         adapter = TrackSearchAdapter(currentTrackUrl) { which ->
-            binding!!.toolbar.menu.findItem(R.id.done).isEnabled = which != null
+            menuItemOK.isEnabled = which != null
+            menuItemOK.setVisible(true)
         }
         binding!!.trackSearchRecyclerview.adapter = adapter
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -66,22 +66,17 @@ class TrackSearchDialog : DialogController {
         binding!!.toolbar.menu.findItem(R.id.done).setVisible(false)
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
         binding!!.trackBtn.setOnClickListener {
-            when (it.id) {
-                R.id.track_btn -> {
-                    val adapter = adapter ?: return@setOnClickListener
-                    val item = adapter.items.getOrNull(adapter.selectedItemPosition)
-                    if (item != null) {
-                        trackController.presenter.registerTracking(item, service)
-                        dialog?.dismiss()
-                    }
-                }
+            val adapter = adapter ?: return@setOnClickListener
+            val item = adapter.items.getOrNull(adapter.selectedItemPosition)
+            if (item != null) {
+                trackController.presenter.registerTracking(item, service)
+                dialog?.dismiss()
             }
         }
 
         // Create adapter
         adapter = TrackSearchAdapter(currentTrackUrl) { which ->
-            binding!!.trackBtn.isClickable = which != null
-            binding!!.trackBtn.isEnabled = true
+            binding!!.trackBtn.isEnabled = which != null
         }
         binding!!.trackSearchRecyclerview.adapter = adapter
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -64,6 +64,7 @@ class TrackSearchDialog : DialogController {
 
         // Toolbar stuff
         binding!!.toolbar.menu.findItem(R.id.done).setVisible(false)
+        binding!!.trackBtn.isVisible = false
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
         binding!!.trackBtn.setOnClickListener {
             when (it.id) {
@@ -81,7 +82,7 @@ class TrackSearchDialog : DialogController {
         // Create adapter
         adapter = TrackSearchAdapter(currentTrackUrl) { which ->
             binding!!.trackBtn.isClickable = which != null
-            binding!!.trackBtn.isVisible
+            binding!!.trackBtn.isVisible = true
         }
         binding!!.trackSearchRecyclerview.adapter = adapter
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -42,8 +42,6 @@ class TrackSearchDialog : DialogController {
 
     private lateinit var currentlySearched: String
 
-    private var menuItemOK = binding!!.toolbar.menu.findItem(R.id.done)
-
     constructor(
         target: MangaController,
         _service: TrackService,
@@ -65,12 +63,12 @@ class TrackSearchDialog : DialogController {
         binding = TrackSearchDialogBinding.inflate(LayoutInflater.from(activity!!))
 
         // Toolbar stuff
+        binding!!.toolbar.menu.findItem(R.id.done).setVisible(false)
         binding!!.toolbar.setNavigationOnClickListener { dialog?.dismiss() }
-        menuItemOK.setVisible(false)
-        binding!!.toolbar.setOnMenuItemClickListener {
-            when (it.itemId) {
-                R.id.done -> {
-                    val adapter = adapter ?: return@setOnMenuItemClickListener true
+        binding!!.trackBtn.setOnClickListener {
+            when (it.id) {
+                R.id.track_btn -> {
+                    val adapter = adapter ?: return@setOnClickListener
                     val item = adapter.items.getOrNull(adapter.selectedItemPosition)
                     if (item != null) {
                         trackController.presenter.registerTracking(item, service)
@@ -78,13 +76,12 @@ class TrackSearchDialog : DialogController {
                     }
                 }
             }
-            true
         }
 
         // Create adapter
         adapter = TrackSearchAdapter(currentTrackUrl) { which ->
-            menuItemOK.isEnabled = which != null
-            menuItemOK.setVisible(true)
+            binding!!.trackBtn.isClickable = which != null
+            binding!!.trackBtn.isVisible
         }
         binding!!.trackSearchRecyclerview.adapter = adapter
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackSearchDialog.kt
@@ -137,6 +137,11 @@ class TrackSearchDialog : DialogController {
                 margin(horizontal = true)
             }
         }
+        binding!!.trackBtn.applyInsetter {
+            type(navigationBars = true) {
+                margin()
+            }
+        }
 
         return AppCompatDialog(activity!!, R.style.ThemeOverlay_Tachiyomi_Dialog_Fullscreen).apply {
             setContentView(binding!!.root)

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -86,6 +86,18 @@
 
         </FrameLayout>
 
+        <Button
+            android:id="@+id/track_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="4dp"
+            android:layout_weight="0"
+            android:text="@string/track_btn"
+            tools:visibility="invisible" />
+
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -95,7 +95,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="4dp"
             android:layout_weight="0"
-            android:text="@string/track_btn"
+            android:text="@string/action_track"
             android:clickable="false"
             android:enabled="false" />
 

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -95,7 +95,9 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="4dp"
             android:layout_weight="0"
-            android:text="@string/track_btn" />
+            android:text="@string/track_btn"
+            android:clickable="false"
+            android:enabled="false" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -95,8 +95,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="4dp"
             android:layout_weight="0"
-            android:text="@string/track_btn"
-            tools:visibility="invisible" />
+            android:text="@string/track_btn" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -17,7 +17,6 @@
             android:layout_height="?attr/actionBarSize"
             android:theme="?attr/actionBarTheme"
             app:contentInsetStartWithNavigation="0dp"
-            app:menu="@menu/track_search"
             app:navigationIcon="@drawable/ic_close_24dp"
             app:title="@string/add_tracking" />
 

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -89,13 +89,9 @@
             android:id="@+id/track_btn"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="4dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="4dp"
-            android:layout_weight="0"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginVertical="4dp"
             android:text="@string/action_track"
-            android:clickable="false"
             android:enabled="false" />
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,6 +396,7 @@
     <string name="tracking_info">One-way sync to update the chapter progress in tracking services. Set up tracking for individual manga entries from their tracking button.</string>
     <string name="enhanced_services">Enhanced services</string>
     <string name="enhanced_tracking_info">Services that provide enhanced features for specific sources. Manga are automatically tracked when added to your library.</string>
+    <string name="track_btn">Track</string>
 
       <!-- Browse section -->
     <string name="pref_enable_automatic_extension_updates">Check for extension updates</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,7 +396,7 @@
     <string name="tracking_info">One-way sync to update the chapter progress in tracking services. Set up tracking for individual manga entries from their tracking button.</string>
     <string name="enhanced_services">Enhanced services</string>
     <string name="enhanced_tracking_info">Services that provide enhanced features for specific sources. Manga are automatically tracked when added to your library.</string>
-    <string name="track_btn">Track</string>
+    <string name="action_track">Track</string>
 
       <!-- Browse section -->
     <string name="pref_enable_automatic_extension_updates">Check for extension updates</string>


### PR DESCRIPTION
If wanting to add a manga to a tracker and it showing only one result, users thought it might automatically select this item. The tick will now appear after selecting an item:

- not having an item selected doesn't show the tick
![2021-08-22_02-04-12](https://user-images.githubusercontent.com/64155117/130337814-45d5fabb-928f-41ac-966c-dce98799971c.png)

- selecting an item enables tick
![2021-08-22_02-04-31](https://user-images.githubusercontent.com/64155117/130337816-9ed30c89-7ca2-4ba1-b544-3d9c4891f6ab.png)

