### PR TITLE
Reattach after slight delay instead on every database update

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -42,9 +42,12 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import reactivecircus.flowbinding.android.view.clicks
 import reactivecircus.flowbinding.viewpager.pageSelections
+import rx.Observable
 import rx.Subscription
+import rx.android.schedulers.AndroidSchedulers
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
 
 class LibraryController(
     bundle: Bundle? = null,
@@ -199,10 +202,12 @@ class LibraryController(
                 is LibrarySettingsSheet.Filter.FilterGroup -> onFilterChanged()
                 is LibrarySettingsSheet.Sort.SortGroup -> onSortChanged()
                 is LibrarySettingsSheet.Display.DisplayGroup -> {
-                    if (!preferences.categorisedDisplaySettings().get() || activeCategory == 0) {
-                        // Reattach adapter when flow preference change
-                        reattachAdapter()
-                    }
+                    val delay = if (preferences.categorisedDisplaySettings().get()) 125L else 0L
+
+                    Observable.timer(delay, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
+                        .subscribe {
+                            reattachAdapter()
+                        }
                 }
                 is LibrarySettingsSheet.Display.BadgeGroup -> onBadgeSettingChanged()
                 is LibrarySettingsSheet.Display.TabsGroup -> onTabsSettingsChanged()
@@ -298,11 +303,6 @@ class LibraryController(
         adapter.itemsPerCategory = adapter.categories
             .map { (it.id ?: -1) to (mangaMap[it.id]?.size ?: 0) }
             .toMap()
-
-        if (preferences.categorisedDisplaySettings().get()) {
-            // Reattach adapter so it doesn't get de-synced
-            reattachAdapter()
-        }
 
         // Restore active category.
         binding.libraryPager.setCurrentItem(activeCat, false)


### PR DESCRIPTION
Currently when updating the library and one has per category display setting enabled it causes scroll lag due to the adapter being reattached.

To fix this a delay is used instead of updating it when the database changes, only when per category display setting is enabled. By delaying the reattach when the display setting gets changed it does not cause the weird behavior fixed by #5640


https://user-images.githubusercontent.com/6576096/134382158-22c28979-e44b-4d28-b437-7a4ac558f3bb.mp4 


https://user-images.githubusercontent.com/6576096/134382179-f1481936-7618-40aa-8676-873715c0099e.mp4 

 