### PR TITLE
Fix local source cover changing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -56,13 +56,11 @@ class LocalSource(private val context: Context) : CatalogueSource {
             if (cover == null) {
                 cover = File("${dir.absolutePath}/${manga.url}", COVER_NAME)
             }
-            if (cover.exists()) {
-                // It might not exist if using the external SD card
-                cover.parentFile?.mkdirs()
-                input.use {
-                    cover.outputStream().use {
-                        input.copyTo(it)
-                    }
+            // It might not exist if using the external SD card
+            cover.parentFile?.mkdirs()
+            input.use {
+                cover.outputStream().use {
+                    input.copyTo(it)
                 }
             }
             return cover

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -56,7 +56,7 @@ class LocalSource(private val context: Context) : CatalogueSource {
             if (cover == null) {
                 cover = File("${dir.absolutePath}/${manga.url}", COVER_NAME)
             }
-            if (!cover.exists()) {
+            if (cover.exists()) {
                 // It might not exist if using the external SD card
                 cover.parentFile?.mkdirs()
                 input.use {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -63,6 +63,7 @@ class LocalSource(private val context: Context) : CatalogueSource {
                     input.copyTo(it)
                 }
             }
+            manga.thumbnail_url = cover.absolutePath
             return cover
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -388,6 +388,7 @@ class MangaPresenter(
                     if (manga.isLocal()) {
                         LocalSource.updateCover(context, manga, it)
                         manga.updateCoverLastModified(db)
+                        db.insertManga(manga).executeAsBlocking()
                         coverCache.clearMemoryCache()
                     } else if (manga.favorite) {
                         coverCache.setCustomCoverToCache(manga, it)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -388,6 +388,7 @@ class MangaPresenter(
                     if (manga.isLocal()) {
                         LocalSource.updateCover(context, manga, it)
                         manga.updateCoverLastModified(db)
+                        coverCache.clearMemoryCache()
                     } else if (manga.favorite) {
                         coverCache.setCustomCoverToCache(manga, it)
                         manga.updateCoverLastModified(db)


### PR DESCRIPTION
fixes #6022

When changing the cover of a local manga, the app crashes and the cover doesn't actually change.
This fixes it by ~reverting a probably accidental exclamation point that got introduced in f0a5557e603e31a53117c40426237d2340142bc2 and~ updating the cover cache so the MangaFullCoverDialog doesn't try to load a recycled image.