### PR TITLE
Add download action to New Chapters Notification

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -514,10 +514,9 @@ class Downloader(
 
     companion object {
         const val TMP_DIR_SUFFIX = "_tmp"
+        const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
     }
 }
-
-private const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
 
 // Arbitrary minimum required space to start a download: 50 MB
 private const val MIN_DISK_SPACE = 50 * 1024 * 1024

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -16,6 +16,7 @@ import coil.transform.CircleCropTransformation
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.download.Downloader
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -212,6 +213,20 @@ class LibraryUpdateNotifier(private val context: Context) {
                     Notifications.ID_NEW_CHAPTERS
                 )
             )
+            // Download chapters action
+            // Only add the action when chapters is within threshold
+            if (chapters.size <= Downloader.CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD) {
+                addAction(
+                    R.drawable.ic_download_24dp,
+                    context.getString(R.string.action_download),
+                    NotificationReceiver.downloadChaptersPendingBroadcast(
+                        context,
+                        manga,
+                        chapters,
+                        Notifications.ID_NEW_CHAPTERS
+                    )
+                )
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -102,6 +102,18 @@ class NotificationReceiver : BroadcastReceiver() {
                     markAsRead(urls, mangaId)
                 }
             }
+            // Download manga chapters
+            ACTION_DOWNLOAD_CHAPTER -> {
+                val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+                if (notificationId > -1) {
+                    dismissNotification(context, notificationId, intent.getIntExtra(EXTRA_GROUP_ID, 0))
+                }
+                val urls = intent.getStringArrayExtra(EXTRA_CHAPTER_URL) ?: return
+                val mangaId = intent.getLongExtra(EXTRA_MANGA_ID, -1)
+                if (mangaId > -1) {
+                    downloadChapters(urls, mangaId)
+                }
+            }
             // Share crash dump file
             ACTION_SHARE_CRASH_LOG ->
                 shareFile(
@@ -235,6 +247,24 @@ class NotificationReceiver : BroadcastReceiver() {
         }
     }
 
+    /**
+     * Method called when user wants to download chapters
+     *
+     * @param chapterUrls URLs of chapter to download
+     * @param mangaId id of manga
+     */
+    private fun downloadChapters(chapterUrls: Array<String>, mangaId: Long) {
+        val db: DatabaseHelper = Injekt.get()
+
+        launchIO {
+            val chapters = chapterUrls.mapNotNull { db.getChapter(it, mangaId).executeAsBlocking() }
+            val manga = db.getManga(mangaId).executeAsBlocking()
+            if (chapters.isNotEmpty() && manga != null) {
+                downloadManager.downloadChapters(manga, chapters)
+            }
+        }
+    }
+
     companion object {
         private const val NAME = "NotificationReceiver"
 
@@ -251,6 +281,7 @@ class NotificationReceiver : BroadcastReceiver() {
 
         private const val ACTION_MARK_AS_READ = "$ID.$NAME.MARK_AS_READ"
         private const val ACTION_OPEN_CHAPTER = "$ID.$NAME.ACTION_OPEN_CHAPTER"
+        private const val ACTION_DOWNLOAD_CHAPTER = "$ID.$NAME.ACTION_DOWNLOAD_CHAPTER"
 
         private const val ACTION_RESUME_DOWNLOADS = "$ID.$NAME.ACTION_RESUME_DOWNLOADS"
         private const val ACTION_PAUSE_DOWNLOADS = "$ID.$NAME.ACTION_PAUSE_DOWNLOADS"
@@ -434,6 +465,28 @@ class NotificationReceiver : BroadcastReceiver() {
         ): PendingIntent {
             val newIntent = Intent(context, NotificationReceiver::class.java).apply {
                 action = ACTION_MARK_AS_READ
+                putExtra(EXTRA_CHAPTER_URL, chapters.map { it.url }.toTypedArray())
+                putExtra(EXTRA_MANGA_ID, manga.id)
+                putExtra(EXTRA_NOTIFICATION_ID, manga.id.hashCode())
+                putExtra(EXTRA_GROUP_ID, groupId)
+            }
+            return PendingIntent.getBroadcast(context, manga.id.hashCode(), newIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
+        /**
+         * Returns [PendingIntent] that downloads chapters
+         *
+         * @param context context of application
+         * @param manga manga of chapter
+         */
+        internal fun downloadChaptersPendingBroadcast(
+            context: Context,
+            manga: Manga,
+            chapters: Array<Chapter>,
+            groupId: Int
+        ): PendingIntent {
+            val newIntent = Intent(context, NotificationReceiver::class.java).apply {
+                action = ACTION_DOWNLOAD_CHAPTER
                 putExtra(EXTRA_CHAPTER_URL, chapters.map { it.url }.toTypedArray())
                 putExtra(EXTRA_MANGA_ID, manga.id)
                 putExtra(EXTRA_NOTIFICATION_ID, manga.id.hashCode())

--- a/app/src/main/res/drawable/ic_download_24dp.xml
+++ b/app/src/main/res/drawable/ic_download_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,3v6L5,9l7,7 7,-7h-4L15,3zM19,18L5,18v2h14v-2z" />
+</vector>


### PR DESCRIPTION
Closes #2986

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
# Description

This PR is for the ability to download chapters through the **New Chapters Notification** actions and not having to open the app or go to the _Manga Screen_. 

- The download button will not appear for new chapters with count greater than 15 (set in `Downloader.CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD`) to minimize mass downloads

## Personal usage experience

When I get notifications for new chapters while reading a **manga/manhwa/manhua** and want to download the new chapter(s), I have to close the _Reader_ and go to the manga's screen to download the new chapters.

Having to close the _Reader_ to download the new chapter(s) is especially annoying with **manhwas/manhuas** because those usually have mega tall aspect ratios per page and coming back to the chapter resets the Reader to the top of the current page.

## Images

New Chapters <= 15
![image](https://user-images.githubusercontent.com/20398239/145438458-02973247-9082-48e2-94ce-b9462504edfd.png)

New Chapters > 15
![image](https://user-images.githubusercontent.com/20398239/145438358-311f672e-74f0-4e55-9c66-b98ed35bf88c.png)
