### PR TITLE
Fix issues with invalid Strings XML entries

### DIFF
--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -569,7 +569,7 @@
     <string name="pref_library_update_refresh_metadata_summary">Kontroli ĉu estas nova kovrio kaj detaloj kiam ĝisdatigas bibliotekon</string>
     <string name="cover_saved">Kovrilo konservita</string>
     <string name="manga_cover">Kovrilo</string>
-    <string name="licensed"/>
+    <string name="licensed">Licencita</string>
     <string name="pref_skip_filtered_chapters">Preterpasi filtritajn ĉapitroj</string>
     <string name="pref_show_navigation_mode_summary">Montri tuŝetzonojn kiam malfermas legilon</string>
     <string name="pref_library_update_refresh_metadata">Aŭtomate aktualigi metadatumoj</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -253,6 +253,6 @@
     <plurals name="num_categories">
         <item quantity="one">Kategorija</item>
         <item quantity="few">Kategorijos</item>
-        <item quantity="other"/>
+        <item quantity="other">Kategorijos</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="name">Nosaukums</string>
     <string name="categories">Kategorijas</string>
-    <string name="manga"/>
+    <string name="manga">Manga</string>
     <string name="chapters">Nodaļas</string>
     <string name="track">Sekošana</string>
     <string name="history">Vēsture</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -345,7 +345,7 @@
     <plurals name="notification_new_chapters_summary">
         <item quantity="one">Pre 1 titul</item>
         <item quantity="few">Pre %d titulov</item>
-        <item quantity="other"/>
+        <item quantity="other">Pre %d titulov</item>
     </plurals>
     <string name="notification_check_updates">Hľadám nové kapitoly</string>
     <string name="hide_notification_content">Skryť obsah upozornení</string>


### PR DESCRIPTION
According to [the docs](https://developer.android.com/guide/topics/resources/string-resource) it's not allowed to have empty start-tags for strings or item entries, which I fixed here. Before, there were multiple Strings files with an opening XML tag (such as `<string name="manga"/>`) but no translation content. This fixes them all.
