### PR TITLE
#5058 fix issue local manga not using title from json file

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -24,6 +24,10 @@ interface SManga : Serializable {
     var initialized: Boolean
 
     fun copyFrom(other: SManga) {
+        if (other.title != null) {
+            title = other.title
+        }
+
         if (other.author != null) {
             author = other.author
         }


### PR DESCRIPTION
Signed-off-by: Laurin Vesely <laurin@vesely-online.de>

#5058 fix issue local manga not using title from json file
When opening a manga from local source the json details including the title will be read.
MangaPresenter.fetchMangaFromSource calls SManga.copyFrom() which now also copies the title that was previously taken from json.
