### PR TITLE
Fix corrupted backup file, fix #6424

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
@@ -32,6 +32,7 @@ import logcat.LogPriority
 import okio.buffer
 import okio.gzip
 import okio.sink
+import java.io.FileOutputStream
 import kotlin.math.max
 
 class FullBackupManager(context: Context) : AbstractBackupManager(context) {
@@ -85,7 +86,10 @@ class FullBackupManager(context: Context) : AbstractBackupManager(context) {
                 ?: throw Exception("Couldn't create backup file")
 
             val byteArray = parser.encodeToByteArray(BackupSerializer, backup!!)
-            file.openOutputStream().sink().gzip().buffer().use { it.write(byteArray) }
+            file.openOutputStream().also {
+                // Force overwrite old file size,
+                (it as? FileOutputStream)?.channel?.truncate(0)
+            }.sink().gzip().buffer().use { it.write(byteArray) }
             val fileUri = file.uri
 
             // Make sure it's a valid backup file


### PR DESCRIPTION
Fixes #6424

Reappear stably on the api30 Android Studio Emulator,
first save a large backup file,
then save a small backup file, overwriting the previous larger backup file,
so you get a backup file with a larger size but only the first part is meaningful,

