### PR TITLE
add option to skip updating mangas where the latest chapter is unread

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
@@ -4,6 +4,7 @@ class LibraryManga : MangaImpl() {
 
     var unreadCount: Int = 0
     var readCount: Int = 0
+    var latestChapterRead: Boolean = false
 
     val totalChapters
         get() = readCount + unreadCount

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -14,7 +14,7 @@ val libraryQuery =
     """
     SELECT M.*, COALESCE(MC.${MangaCategory.COL_CATEGORY_ID}, 0) AS ${Manga.COL_CATEGORY}
     FROM (
-        SELECT ${Manga.TABLE}.*, COALESCE(C.unreadCount, 0) AS ${Manga.COMPUTED_COL_UNREAD_COUNT}, COALESCE(R.readCount, 0) AS ${Manga.COMPUTED_COL_READ_COUNT}
+        SELECT ${Manga.TABLE}.*, COALESCE(C.unreadCount, 0) AS ${Manga.COMPUTED_COL_UNREAD_COUNT}, COALESCE(R.readCount, 0) AS ${Manga.COMPUTED_COL_READ_COUNT}, COALESCE(L.isRead, 0) AS ${Manga.COMPUTED_COL_LATEST_READ}
         FROM ${Manga.TABLE}
         LEFT JOIN (
             SELECT ${Chapter.COL_MANGA_ID}, COUNT(*) AS unreadCount
@@ -30,6 +30,13 @@ val libraryQuery =
             GROUP BY ${Chapter.COL_MANGA_ID}
         ) AS R
         ON ${Manga.COL_ID} = R.${Chapter.COL_MANGA_ID}
+        LEFT JOIN (
+            SELECT ${Chapter.COL_MANGA_ID}, ${Chapter.COL_READ} AS isRead
+            FROM ${Chapter.TABLE}
+            ORDER BY ${Chapter.COL_CHAPTER_NUMBER} DESC
+            LIMIT 1
+        ) AS L
+        ON ${Manga.COL_ID} = L.${Chapter.COL_MANGA_ID}
         WHERE ${Manga.COL_FAVORITE} = 1
         GROUP BY ${Manga.COL_ID}
         ORDER BY ${Manga.COL_TITLE}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/LibraryMangaGetResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/LibraryMangaGetResolver.kt
@@ -19,6 +19,7 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
         manga.unreadCount = cursor.getInt(cursor.getColumnIndexOrThrow(MangaTable.COMPUTED_COL_UNREAD_COUNT))
         manga.category = cursor.getInt(cursor.getColumnIndexOrThrow(MangaTable.COL_CATEGORY))
         manga.readCount = cursor.getInt(cursor.getColumnIndexOrThrow(MangaTable.COMPUTED_COL_READ_COUNT))
+        manga.latestChapterRead = cursor.getInt(cursor.getColumnIndexOrThrow(MangaTable.COMPUTED_COL_LATEST_READ)) != 0
 
         return manga
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
@@ -46,6 +46,8 @@ object MangaTable {
     // Not an actual value but computed when created
     const val COMPUTED_COL_UNREAD_COUNT = "unread_count"
 
+    const val COMPUTED_COL_LATEST_READ = "latest_read"
+
     const val COMPUTED_COL_READ_COUNT = "read_count"
 
     val createTableQuery: String

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -20,6 +20,7 @@ import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.MANGA_HAS_UNREAD
+import eu.kanade.tachiyomi.data.preference.MANGA_LATEST_UNREAD
 import eu.kanade.tachiyomi.data.preference.MANGA_NON_COMPLETED
 import eu.kanade.tachiyomi.data.preference.MANGA_NON_READ
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -319,6 +320,9 @@ class LibraryUpdateService(
                                             }
                                             MANGA_HAS_UNREAD in restrictions && manga.unreadCount != 0 -> {
                                                 skippedUpdates.add(manga to getString(R.string.skipped_reason_not_caught_up))
+                                            }
+                                            MANGA_LATEST_UNREAD in restrictions && !manga.latestChapterRead -> {
+                                                skippedUpdates.add(manga to getString(R.string.skipped_reason_not_latest_unread))
                                             }
                                             MANGA_NON_READ in restrictions && manga.totalChapters > 0 && !manga.hasStarted -> {
                                                 skippedUpdates.add(manga to getString(R.string.skipped_reason_not_started))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -8,6 +8,7 @@ const val DEVICE_CHARGING = "ac"
 const val MANGA_NON_COMPLETED = "manga_ongoing"
 const val MANGA_HAS_UNREAD = "manga_fully_read"
 const val MANGA_NON_READ = "manga_started"
+const val MANGA_LATEST_UNREAD = "manga_latest_read"
 
 /**
  * This class stores the values for the preferences in the application.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -224,7 +224,7 @@ class PreferencesHelper(val context: Context) {
     fun libraryUpdateInterval() = flowPrefs.getInt("pref_library_update_interval_key", 24)
 
     fun libraryUpdateDeviceRestriction() = flowPrefs.getStringSet("library_update_restriction", setOf(DEVICE_ONLY_ON_WIFI))
-    fun libraryUpdateMangaRestriction() = flowPrefs.getStringSet("library_update_manga_restriction", setOf(MANGA_HAS_UNREAD, MANGA_NON_COMPLETED, MANGA_NON_READ))
+    fun libraryUpdateMangaRestriction() = flowPrefs.getStringSet("library_update_manga_restriction", setOf(MANGA_HAS_UNREAD, MANGA_NON_COMPLETED, MANGA_NON_READ, MANGA_LATEST_UNREAD))
 
     fun showUpdatesNavBadge() = flowPrefs.getBoolean("library_update_show_tab_badge", false)
     fun unreadUpdatesCount() = flowPrefs.getInt("library_unread_updates_count", 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.DEVICE_CHARGING
 import eu.kanade.tachiyomi.data.preference.DEVICE_ONLY_ON_WIFI
 import eu.kanade.tachiyomi.data.preference.MANGA_HAS_UNREAD
+import eu.kanade.tachiyomi.data.preference.MANGA_LATEST_UNREAD
 import eu.kanade.tachiyomi.data.preference.MANGA_NON_COMPLETED
 import eu.kanade.tachiyomi.data.preference.MANGA_NON_READ
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -196,8 +197,8 @@ class SettingsLibraryController : SettingsController() {
             multiSelectListPreference {
                 bindTo(preferences.libraryUpdateMangaRestriction())
                 titleRes = R.string.pref_library_update_manga_restriction
-                entriesRes = arrayOf(R.string.pref_update_only_completely_read, R.string.pref_update_only_started, R.string.pref_update_only_non_completed)
-                entryValues = arrayOf(MANGA_HAS_UNREAD, MANGA_NON_READ, MANGA_NON_COMPLETED)
+                entriesRes = arrayOf(R.string.pref_update_only_completely_read, R.string.pref_update_only_started, R.string.pref_update_only_non_completed, R.string.pref_update_only_when_latest_read)
+                entryValues = arrayOf(MANGA_HAS_UNREAD, MANGA_NON_READ, MANGA_NON_COMPLETED, MANGA_LATEST_UNREAD)
 
                 fun updateSummary() {
                     val restrictions = preferences.libraryUpdateMangaRestriction().get().sorted()
@@ -206,6 +207,7 @@ class SettingsLibraryController : SettingsController() {
                                 MANGA_NON_READ -> context.getString(R.string.pref_update_only_started)
                                 MANGA_HAS_UNREAD -> context.getString(R.string.pref_update_only_completely_read)
                                 MANGA_NON_COMPLETED -> context.getString(R.string.pref_update_only_non_completed)
+                                MANGA_LATEST_UNREAD -> context.getString(R.string.pref_update_only_when_latest_read)
                                 else -> it
                             }
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,7 @@
     <string name="pref_library_update_manga_restriction">Skip updating</string>
     <string name="pref_update_only_completely_read">Has unread chapters</string>
     <string name="pref_update_only_non_completed">Is completed series</string>
+    <string name="pref_update_only_when_latest_read">Latest chapter is unread</string>
     <string name="pref_update_only_started">No read chapters</string>
     <string name="pref_library_update_show_tab_badge">Show unread count on Updates icon</string>
     <string name="pref_library_update_refresh_metadata">Automatically refresh metadata</string>
@@ -745,6 +746,7 @@
     <string name="library_errors_help">For help on how to fix library update errors, see %1$s</string>
     <string name="skipped_reason_completed">Skipped because series is complete</string>
     <string name="skipped_reason_not_caught_up">Skipped because there are unread chapters</string>
+    <string name="skipped_reason_not_latest_unread">Skipped because the latest chapter has not been read</string>
     <string name="skipped_reason_not_started">Skipped because no chapters are read</string>
 
     <!-- File Picker Titles -->


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

This adds the setting I suggested in #6788. I am sorry I got a bit frustrated in that issue.
I implemented the change myself and would appreciate if you could merge it, especially since there aren't really any downsides to doing so.

I also think it would make sense to make this the default instead of "all chapters read" because I think it will reduce the number of normal users wondering why they are missing updates but I won't argue on that matter.

Thank you.

P.S.: this is missing translations, please let me know if I should have put a dummy value for missing translations or if this is fine.
