### PR TITLE
Add option to disable navigation layout

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/DisabledNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/DisabledNavigation.kt
@@ -1,0 +1,18 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.navigation
+
+import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
+
+/**
+ * Visualization of default state without any inversion
+ * +---+---+---+
+ * | M | M | M |   P: Previous
+ * +---+---+---+
+ * | M | M | M |   M: Menu
+ * +---+---+---+
+ * | M | M | M |   N: Next
+ * +---+---+---+
+*/
+class DisabledNavigation : ViewerNavigation() {
+
+    override var regions: List<Region> = listOf()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerConfig
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.EdgeNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.KindlishNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.LNavigation
@@ -131,6 +132,7 @@ class PagerConfig(
             2 -> KindlishNavigation()
             3 -> EdgeNavigation()
             4 -> RightAndLeftNavigation()
+            5 -> DisabledNavigation()
             else -> defaultNavigation()
         }
         navigationModeChangedListener?.invoke()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerConfig
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.EdgeNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.KindlishNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.navigation.LNavigation
@@ -79,6 +80,7 @@ class WebtoonConfig(
             2 -> KindlishNavigation()
             3 -> EdgeNavigation()
             4 -> RightAndLeftNavigation()
+            5 -> DisabledNavigation()
             else -> defaultNavigation()
         }
         navigationModeChangedListener?.invoke()

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -85,6 +85,7 @@
         <item>@string/kindlish_nav</item>
         <item>@string/edge_nav</item>
         <item>@string/right_and_left_nav</item>
+        <item>@string/disabled_nav</item>
     </string-array>
 
     <string-array name="webtoon_nav">
@@ -93,5 +94,6 @@
         <item>@string/kindlish_nav</item>
         <item>@string/edge_nav</item>
         <item>@string/right_and_left_nav</item>
+        <item>@string/disabled_nav</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,7 @@
     <string name="kindlish_nav">Kindle-ish</string>
     <string name="edge_nav">Edge</string>
     <string name="right_and_left_nav">Right and Left</string>
+    <string name="disabled_nav">Disabled</string>
     <string name="nav_zone_prev">Prev</string>
     <string name="nav_zone_next">Next</string>
     <string name="nav_zone_left">Left</string>


### PR DESCRIPTION
I added a navigation layout "Disabled" that doesn't contain any regions.

In many popular vertical reading apps like Naver Webtoon, navigation is entirely done by scrolling.
Users who are accustomed to such navigation system might get some unintentional page movements with current layouts, so I am proposing to add this option.

Closes #4820