### PR TITLE
feat(library-update): can update even if job is already running

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
@@ -111,6 +111,8 @@ class LibraryCategoryView @JvmOverloads constructor(context: Context, attrs: Att
             .onEach {
                 if (LibraryUpdateService.start(context, category)) {
                     context.toast(R.string.updating_category)
+                } else {
+                    context.toast(R.string.pushing_update_to_queue)
                 }
 
                 // It can be a very long operation, so we disable swipe refresh and show a toast.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -699,6 +699,7 @@
 
     <!-- Updates fragment -->
     <string name="updating_library">Updating library</string>
+    <string name="pushing_update_to_queue">Already updating, pushing update to queue</string>
 
     <!-- History fragment -->
     <string name="recent_manga_time">Ch. %1$s - %2$s</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Fix [this issue](https://github.com/tachiyomiorg/tachiyomi/issues/460). 

I change the `mangaToUpdate` from a `List` to a `Subject`. This way when we addMangaToQueue it's handle by the current running update function.

*Note that I'm new to Kotlin, and I'm not 100% sure that the async operation are handle the perfect way, but I'm sure it's working*


