### PR TITLE
Remove resume button pr

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -1,39 +1,25 @@
 package eu.kanade.presentation.history
 
-import android.view.View
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -54,7 +40,7 @@ import uy.kohesive.injekt.api.get
 import java.text.DateFormat
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
-import java.util.Date
+import java.util.*
 
 @Composable
 fun HistoryScreen(

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -1,5 +1,6 @@
 package eu.kanade.presentation.history
 
+import android.view.View
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
@@ -13,16 +14,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,14 +23,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -184,13 +180,15 @@ fun HistoryItem(
 ) {
     Row(
         modifier = modifier
-            .clickable(onClick = onClickItem)
+            .clickable(onClick = onClickResume)
             .height(96.dp)
             .padding(horizontal = horizontalPadding, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         MangaCover(
-            modifier = Modifier.fillMaxHeight(),
+            modifier = Modifier
+                .fillMaxHeight()
+                .clickable(onClick = onClickItem),
             data = history.thumbnailUrl,
             aspect = MangaCoverAspect.COVER
         )
@@ -224,17 +222,11 @@ fun HistoryItem(
                 )
             }
         }
+
         IconButton(onClick = onClickDelete) {
             Icon(
                 imageVector = Icons.Outlined.Delete,
                 contentDescription = stringResource(id = R.string.action_delete),
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-        IconButton(onClick = onClickResume) {
-            Icon(
-                imageVector = Icons.Filled.PlayArrow,
-                contentDescription = stringResource(id = R.string.action_resume),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -60,7 +60,7 @@ import java.util.Date
 fun HistoryScreen(
     composeView: ComposeView,
     presenter: HistoryPresenter,
-    onClickItem: (HistoryWithRelations) -> Unit,
+    onClickCover: (HistoryWithRelations) -> Unit,
     onClickResume: (HistoryWithRelations) -> Unit,
     onClickDelete: (HistoryWithRelations, Boolean) -> Unit,
 ) {
@@ -80,7 +80,7 @@ fun HistoryScreen(
             HistoryContent(
                 nestedScroll = nestedScrollInterop,
                 history = history,
-                onClickItem = onClickItem,
+                onClickCover = onClickCover,
                 onClickResume = onClickResume,
                 onClickDelete = onClickDelete,
             )
@@ -91,7 +91,7 @@ fun HistoryScreen(
 @Composable
 fun HistoryContent(
     history: LazyPagingItems<UiModel>,
-    onClickItem: (HistoryWithRelations) -> Unit,
+    onClickCover: (HistoryWithRelations) -> Unit,
     onClickResume: (HistoryWithRelations) -> Unit,
     onClickDelete: (HistoryWithRelations, Boolean) -> Unit,
     preferences: PreferencesHelper = Injekt.get(),
@@ -124,7 +124,7 @@ fun HistoryContent(
                     HistoryItem(
                         modifier = Modifier.animateItemPlacement(),
                         history = value,
-                        onClickItem = { onClickItem(value) },
+                        onClickCover = { onClickCover(value) },
                         onClickResume = { onClickResume(value) },
                         onClickDelete = { setRemoveState(value) },
                     )
@@ -174,7 +174,7 @@ fun HistoryHeader(
 fun HistoryItem(
     modifier: Modifier = Modifier,
     history: HistoryWithRelations,
-    onClickItem: () -> Unit,
+    onClickCover: () -> Unit,
     onClickResume: () -> Unit,
     onClickDelete: () -> Unit,
 ) {
@@ -188,7 +188,7 @@ fun HistoryItem(
         MangaCover(
             modifier = Modifier
                 .fillMaxHeight()
-                .clickable(onClick = onClickItem),
+                .clickable(onClick = onClickCover),
             data = history.thumbnailUrl,
             aspect = MangaCoverAspect.COVER
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryController.kt
@@ -32,7 +32,7 @@ class HistoryController : ComposeController<HistoryPresenter>(), RootController 
         HistoryScreen(
             composeView = binding.root,
             presenter = presenter,
-            onClickItem = { history ->
+            onClickCover = { history ->
                 router.pushController(MangaController(history).withFadeTransaction())
             },
             onClickResume = { history ->


### PR DESCRIPTION
Makes the whole item the resume button, and you press the cover to get to manga info

### Images
| Before | After |
| ------- | ------- |
| ![crinj old item with resume button](https://user-images.githubusercontent.com/70870719/164559173-c0ac62b5-8537-4678-8947-23f94b35f15a.png) | ![chad no dumb play button](https://user-images.githubusercontent.com/70870719/164558916-eebee309-e844-49d8-a77b-e6c50873a141.png) |
