### PR TITLE
fix downloader stuck as foreground service

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -82,8 +82,8 @@ class DownloadManager(
      *
      * @param reason an optional reason for being stopped, used to notify the user.
      */
-    fun stopDownloads(reason: String? = null) {
-        downloader.stop(reason)
+    fun stopDownloads(reason: String? = null, suppressCompletionNotification: Boolean = false) {
+        downloader.stop(reason, suppressCompletionNotification)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadService.kt
@@ -158,18 +158,22 @@ class DownloadService : Service() {
     private fun onNetworkStateChanged() {
         if (isOnline()) {
             if (preferences.downloadOnlyOverWifi() && !isConnectedToWifi()) {
-                stopDownloads(R.string.download_notifier_text_only_wifi)
+                handleNetworkUnavailable(R.string.download_notifier_text_only_wifi)
             } else {
                 val started = downloadManager.startDownloads()
                 if (!started) stopSelf()
             }
         } else {
-            stopDownloads(R.string.download_notifier_no_network)
+            handleNetworkUnavailable(R.string.download_notifier_no_network)
         }
     }
 
-    private fun stopDownloads(@StringRes string: Int) {
-        downloadManager.stopDownloads(getString(string))
+    private fun handleNetworkUnavailable(@StringRes message: Int) {
+        // stop current downloads with a error notification
+        downloadManager.stopDownloads(getString(message))
+
+        // stop the service to prevent it from lingering in the background
+        stopSelf()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -138,7 +138,7 @@ class Downloader(
     /**
      * Stops the downloader.
      */
-    fun stop(reason: String? = null) {
+    fun stop(reason: String? = null, suppressCompletionNotification: Boolean = false) {
         destroySubscriptions()
         queue
             .filter { it.status == Download.State.DOWNLOADING }
@@ -151,7 +151,7 @@ class Downloader(
 
         if (notifier.paused && !queue.isEmpty()) {
             notifier.onPaused()
-        } else {
+        } else if (!suppressCompletionNotification) {
             notifier.onComplete()
         }
 


### PR DESCRIPTION
After updating to Android 12 (or maybe it was with a app update, can't really tell) i started getting a persistent "App is running in backgrund" notification, and had to force- stop tachiyomi to get rid of it. 
As it seems, this is because the download service is started as a background service, and gets stuck when stopping downloads due to no suitable network being available. With my change, the download service is stopped in this case. 


| Notification: Tachiyomi running in background | 
| ------- | 
| ![tachi-running-in-bg](https://user-images.githubusercontent.com/52449218/166710900-b746971e-6d8f-4c2c-a857-bd94fac3607d.png) | 


---

Note: I'm currently testing this change and will mark the PR ready if testing goes well


