### PR TITLE
Fix global update ignoring network constraint

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -8,10 +8,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import eu.kanade.tachiyomi.data.preference.DEVICE_BATTERY_NOT_LOW
-import eu.kanade.tachiyomi.data.preference.DEVICE_CHARGING
-import eu.kanade.tachiyomi.data.preference.DEVICE_ONLY_ON_WIFI
-import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.preference.*
 import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -43,7 +40,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             if (interval > 0) {
                 val restrictions = preferences.libraryUpdateDeviceRestriction().get()
                 val constraints = Constraints.Builder()
-                    .setRequiredNetworkType(if (DEVICE_ONLY_ON_WIFI in restrictions) { NetworkType.UNMETERED } else { NetworkType.CONNECTED })
+                    .setRequiredNetworkType(if (DEVICE_NETWORK_NOT_METERED in restrictions) { NetworkType.UNMETERED } else { NetworkType.CONNECTED })
                     .setRequiresCharging(DEVICE_CHARGING in restrictions)
                     .setRequiresBatteryNotLow(DEVICE_BATTERY_NOT_LOW in restrictions)
                     .build()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceValues.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.preference
 import eu.kanade.tachiyomi.R
 
 const val DEVICE_ONLY_ON_WIFI = "wifi"
+const val DEVICE_NETWORK_NOT_METERED = "network_not_metered"
 const val DEVICE_CHARGING = "ac"
 const val DEVICE_BATTERY_NOT_LOW = "battery_not_low"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -11,13 +11,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
-import eu.kanade.tachiyomi.data.preference.DEVICE_BATTERY_NOT_LOW
-import eu.kanade.tachiyomi.data.preference.DEVICE_CHARGING
-import eu.kanade.tachiyomi.data.preference.DEVICE_ONLY_ON_WIFI
-import eu.kanade.tachiyomi.data.preference.MANGA_HAS_UNREAD
-import eu.kanade.tachiyomi.data.preference.MANGA_NON_COMPLETED
-import eu.kanade.tachiyomi.data.preference.MANGA_NON_READ
-import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.preference.*
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.databinding.PrefLibraryColumnsBinding
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
@@ -152,8 +146,8 @@ class SettingsLibraryController : SettingsController() {
             multiSelectListPreference {
                 bindTo(preferences.libraryUpdateDeviceRestriction())
                 titleRes = R.string.pref_library_update_restriction
-                entriesRes = arrayOf(R.string.connected_to_wifi, R.string.charging, R.string.battery_not_low)
-                entryValues = arrayOf(DEVICE_ONLY_ON_WIFI, DEVICE_CHARGING, DEVICE_BATTERY_NOT_LOW)
+                entriesRes = arrayOf(R.string.connected_to_wifi, R.string.network_not_metered, R.string.charging, R.string.battery_not_low)
+                entryValues = arrayOf(DEVICE_ONLY_ON_WIFI, DEVICE_NETWORK_NOT_METERED, DEVICE_CHARGING, DEVICE_BATTERY_NOT_LOW)
 
                 visibleIf(preferences.libraryUpdateInterval()) { it > 0 }
 
@@ -169,6 +163,7 @@ class SettingsLibraryController : SettingsController() {
                         .map {
                             when (it) {
                                 DEVICE_ONLY_ON_WIFI -> context.getString(R.string.connected_to_wifi)
+                                DEVICE_NETWORK_NOT_METERED -> context.getString(R.string.network_not_metered)
                                 DEVICE_CHARGING -> context.getString(R.string.charging)
                                 DEVICE_BATTERY_NOT_LOW -> context.getString(R.string.battery_not_low)
                                 else -> it

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="update_weekly">Weekly</string>
     <string name="pref_library_update_restriction">Automatic updates device restrictions</string>
     <string name="connected_to_wifi">Only on Wi-Fi</string>
+    <string name="network_not_metered">Only on unmetered Network</string>
     <string name="charging">Charging</string>
     <string name="battery_not_low">Battery not low</string>
     <string name="restrictions">Restrictions: %s</string>


### PR DESCRIPTION
Fixes automatic library updates ignoring network constraint and closes #7016 .

Note: I've added a constraint for unmetered network to the work request. That way, the job will run as soon as a unmetered (== wifi) connection is available instead of waiting for the next run in however many hours the user set it to. 


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
