### PR TITLE
Fix stacking of Settings menu in the reader on multiple taps

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -512,11 +512,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
             val readerSettingSheetDialog = ReaderSettingsSheet(this@ReaderActivity)
             setOnClickListener {
                 if (!readerSettingSheetDialog.isShowing()) {
-                    userCanTap = true
-                }
-                if (userCanTap) {
                     readerSettingSheetDialog.show()
-                    userCanTap = false
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -507,7 +507,6 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
 
         // Settings sheet
         with(binding.actionSettings) {
-            var userCanTap = true
             setTooltip(R.string.action_settings)
             val readerSettingSheetDialog = ReaderSettingsSheet(this@ReaderActivity)
             setOnClickListener {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -507,10 +507,17 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
 
         // Settings sheet
         with(binding.actionSettings) {
+            var userCanTap = true
             setTooltip(R.string.action_settings)
-
+            val readerSettingSheetDialog = ReaderSettingsSheet(this@ReaderActivity)
             setOnClickListener {
-                ReaderSettingsSheet(this@ReaderActivity).show()
+                if (!readerSettingSheetDialog.isShowing()) {
+                    userCanTap = true
+                }
+                if (userCanTap) {
+                    readerSettingSheetDialog.show()
+                    userCanTap = false
+                }
             }
 
             setOnLongClickListener {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
         // Pinning to older version of R8 due to weird forced optimizations in newer versions in
         // version bundled with AGP
         // https://mvnrepository.com/artifact/com.android.tools/r8?repo=google
-        classpath("com.android.tools:r8:3.1.66")
+        classpath("com.android.tools:r8:3.3.75")
         classpath(libs.android.shortcut.gradle)
         classpath(libs.google.services.gradle)
         classpath(libs.aboutLibraries.gradle)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
         // Pinning to older version of R8 due to weird forced optimizations in newer versions in
         // version bundled with AGP
         // https://mvnrepository.com/artifact/com.android.tools/r8?repo=google
-        classpath("com.android.tools:r8:3.3.75")
+        classpath("com.android.tools:r8:3.1.66")
         classpath(libs.android.shortcut.gradle)
         classpath(libs.google.services.gradle)
         classpath(libs.aboutLibraries.gradle)


### PR DESCRIPTION
Closes  #7940 

This fixed the issue of multiple bottom sheets stacking up, by adding a conditional check. 

https://user-images.githubusercontent.com/55742309/189731367-b329ac11-3603-4e8a-9b1b-9b7d9973370b.mp4

In Fix:
- Bottom sheet is being opened depending on status whether dialog sheet  is currently showing or not.
- If dialog sheet is opened once, code for opening dialog sheet won't be executed unless the user closes the  opened bottom sheet first.



