### PR TITLE
Only reset filterSheet to source settings instead of changing state

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceController.kt
@@ -124,8 +124,7 @@ open class BrowseSourceController(bundle: Bundle) :
                 presenter.setSourceFilter(presenter.filters)
             },
             onResetClicked = {
-                presenter.resetFilter()
-                filterSheet?.setFilters(presenter.filterItems)
+                filterSheet?.setFilters(presenter.source!!.getFilterList().toItems())
             },
         )
 


### PR DESCRIPTION
Fixes #8015

This fixes the behavior found in #8015, where the filter button doesn't do anything.

The current behavior is caused by `resetFilter`:

https://github.com/tachiyomiorg/tachiyomi/blob/0086743a5311c22fb8c07f596ab5de384862a68a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourcePresenter.kt#L158-L161

When we first go into the filtering modal, the filter type of `presenter.currentFilter` is still set to `Filter.Popular` (or `Filter.Latest`). This means that the user input is completed ignored in the `resetFilter` call, and nothing changes in the filtering modal. Alternatively, the catalogue is changed from underneath if the previous filter was a user filter, before even hitting the filter button.

This change just sets the filterSheet to the source's default filters, without actually making state changes. I've done some manual testing, and this seems to be the correct behavior (at least from what I expect).