### PR TITLE
Implementation of pdf loader

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
 import eu.kanade.tachiyomi.util.lang.withIOContext
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.EpubFile
+import eu.kanade.tachiyomi.util.storage.PdfFile
 import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.logcat
 import kotlinx.coroutines.runBlocking
@@ -351,6 +352,7 @@ class LocalSource(
             extension.equals("zip", true) || extension.equals("cbz", true) -> Format.Zip(this)
             extension.equals("rar", true) || extension.equals("cbr", true) -> Format.Rar(this)
             extension.equals("epub", true) -> Format.Epub(this)
+            extension.equals("pdf", true) -> Format.Pdf(this)
             else -> throw Exception(context.getString(R.string.local_invalid_format))
         }
     }
@@ -392,6 +394,14 @@ class LocalSource(
                         entry?.let { updateCover(context, manga, epub.getInputStream(it)) }
                     }
                 }
+                is Format.Pdf -> {
+                    PdfFile(format.file).use { pdf ->
+                        val entry = pdf.getImagesFromPages()
+                            .firstOrNull()
+
+                        entry?.let { updateCover(context, manga, pdf.getInputStream(it)) }
+                    }
+                }
             }
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e) { "Error updating cover for ${manga.title}" }
@@ -404,6 +414,7 @@ class LocalSource(
         data class Zip(val file: File) : Format()
         data class Rar(val file: File) : Format()
         data class Epub(val file: File) : Format()
+        data class Pdf(val file: File) : Format()
     }
 
     companion object {
@@ -481,5 +492,5 @@ class LocalSource(
     }
 }
 
-private val SUPPORTED_ARCHIVE_TYPES = listOf("zip", "cbz", "rar", "cbr", "epub")
+private val SUPPORTED_ARCHIVE_TYPES = listOf("zip", "cbz", "rar", "cbr", "epub", "pdf")
 private val COMIC_INFO_FILE = "ComicInfo.xml"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CachedPdfPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CachedPdfPageLoader.kt
@@ -1,0 +1,256 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import eu.kanade.tachiyomi.data.cache.ChapterCache
+import eu.kanade.tachiyomi.data.database.models.toDomainChapter
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.util.lang.plusAssign
+import eu.kanade.tachiyomi.util.storage.PdfFile
+import eu.kanade.tachiyomi.util.system.logcat
+import logcat.LogPriority
+import rx.Completable
+import rx.Observable
+import rx.schedulers.Schedulers
+import rx.subjects.PublishSubject
+import rx.subjects.SerializedSubject
+import rx.subscriptions.CompositeSubscription
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+import java.util.concurrent.PriorityBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.min
+
+/**
+ * Loader used to load chapters from an pdf source.
+ */
+class CachedPdfPageLoader(
+    private val file: File,
+    private val chapter: ReaderChapter,
+    private val chapterCache: ChapterCache = Injekt.get(),
+) : PageLoader() {
+
+    private val source = PdfFile(file)
+
+    /**
+     * A queue used to manage requests one by one while allowing priorities.
+     */
+    private val queue = PriorityBlockingQueue<PriorityPage>()
+
+    /**
+     * Current active subscriptions.
+     */
+    private val subscriptions = CompositeSubscription()
+
+    private val preloadSize = 8
+
+    init {
+        subscriptions += Observable.defer { Observable.just(queue.take().page) }
+            .filter { it.status == Page.QUEUE }
+            .concatMap { source.fetchImageFromCacheThenNet(it) }
+            .repeat()
+            .subscribeOn(Schedulers.io())
+            .subscribe(
+                {
+                },
+                { error ->
+                    if (error !is InterruptedException) {
+                        logcat(LogPriority.ERROR, error)
+                    }
+                },
+            )
+    }
+
+    /**
+     * Recycles this loader and the active subscriptions and queue.
+     */
+    override fun recycle() {
+        super.recycle()
+        subscriptions.unsubscribe()
+        queue.clear()
+
+        // Cache current page list progress for online chapters to allow a faster reopen
+        val pages = chapter.pages
+        if (pages != null) {
+            Completable
+                .fromAction {
+                    // Convert to pages without reader information
+                    val pagesToSave = pages.map { Page(it.index, it.url, it.imageUrl) }
+                    chapterCache.putPageListToCache(
+                        chapter.chapter.toDomainChapter()!!,
+                        pagesToSave,
+                    )
+                }
+                .onErrorComplete()
+                .subscribeOn(Schedulers.io())
+                .subscribe()
+        }
+    }
+
+    /**
+     * Returns an observable with the page list for a chapter. It tries to return the page list from
+     * the local cache, otherwise fallbacks to network.
+     */
+    override fun getPages(): Observable<List<ReaderPage>> {
+        return Observable.fromCallable { chapterCache.getPageListFromCache(chapter.chapter.toDomainChapter()!!) }
+            .onErrorResumeNext { Observable.just(source.getImagesFromPages().map { Page(it) }) }
+            .map { pages ->
+                pages.mapIndexed { index, page ->
+                    // Don't trust sources and use our own indexing
+                    ReaderPage(index, page.url, page.imageUrl)
+                }
+            }
+    }
+
+    /**
+     * Returns an observable that loads a page through the queue and listens to its result to
+     * emit new states. It handles re-enqueueing pages if they were evicted from the cache.
+     */
+    override fun getPage(page: ReaderPage): Observable<Int> {
+        return Observable.defer {
+            val imageUrl = page.imageUrl
+
+            // Check if the image has been deleted
+            if (page.status == Page.READY && imageUrl != null && !chapterCache.isImageInCache(
+                    imageUrl,
+                )
+            ) {
+                page.status = Page.QUEUE
+            }
+
+            // Automatically retry failed pages when subscribed to this page
+            if (page.status == Page.ERROR) {
+                page.status = Page.QUEUE
+            }
+
+            val statusSubject = SerializedSubject(PublishSubject.create<Int>())
+            page.setStatusSubject(statusSubject)
+
+            val queuedPages = mutableListOf<PriorityPage>()
+            if (page.status == Page.QUEUE) {
+                queuedPages += PriorityPage(page, 1).also { queue.offer(it) }
+            }
+            queuedPages += preloadNextPages(page, preloadSize)
+
+            statusSubject.startWith(page.status)
+                .doOnUnsubscribe {
+                    queuedPages.forEach {
+                        if (it.page.status == Page.QUEUE) {
+                            queue.remove(it)
+                        }
+                    }
+                }
+        }
+            .subscribeOn(Schedulers.io())
+            .unsubscribeOn(Schedulers.io())
+    }
+
+    /**
+     * Preloads the given [amount] of pages after the [currentPage] with a lower priority.
+     * @return a list of [PriorityPage] that were added to the [queue]
+     */
+    private fun preloadNextPages(currentPage: ReaderPage, amount: Int): List<PriorityPage> {
+        val pageIndex = currentPage.index
+        val pages = currentPage.chapter.pages ?: return emptyList()
+        if (pageIndex == pages.lastIndex) return emptyList()
+
+        return pages
+            .subList(pageIndex + 1, min(pageIndex + 1 + amount, pages.size))
+            .mapNotNull {
+                if (it.status == Page.QUEUE) {
+                    PriorityPage(it, 0).apply { queue.offer(this) }
+                } else {
+                    null
+                }
+            }
+    }
+
+    /**
+     * Retries a page. This method is only called from user interaction on the viewer.
+     */
+    override fun retryPage(page: ReaderPage) {
+        if (page.status == Page.ERROR) {
+            page.status = Page.QUEUE
+        }
+        queue.offer(PriorityPage(page, 2))
+    }
+
+    /**
+     * Data class used to keep ordering of pages in order to maintain priority.
+     */
+    private class PriorityPage(
+        val page: ReaderPage,
+        val priority: Int,
+    ) : Comparable<PriorityPage> {
+        companion object {
+            private val idGenerator = AtomicInteger()
+        }
+
+        private val identifier = idGenerator.incrementAndGet()
+
+        override fun compareTo(other: PriorityPage): Int {
+            val p = other.priority.compareTo(priority)
+            return if (p != 0) p else identifier.compareTo(other.identifier)
+        }
+    }
+
+    /**
+     * Returns an observable of the page with the downloaded image.
+     *
+     * @param page the page whose source image has to be downloaded.
+     */
+    private fun PdfFile.fetchImageFromCacheThenNet(page: ReaderPage): Observable<ReaderPage> {
+        return if (page.imageUrl.isNullOrEmpty()) {
+            getImageUrl(page).flatMap { getCachedImage(it) }
+        } else {
+            getCachedImage(page)
+        }
+    }
+
+    private fun getImageUrl(page: ReaderPage): Observable<ReaderPage> {
+        page.status = Page.LOAD_PAGE
+        return Observable.just(file.path + "#${page.index}")
+            .doOnError { page.status = Page.ERROR }
+            .onErrorReturn { null }
+            .doOnNext { page.imageUrl = it }
+            .map { page }
+    }
+
+    /**
+     * Returns an observable of the page that gets the image from the chapter or fallbacks to
+     * network and copies it to the cache calling [cacheImage].
+     *
+     * @param page the page.
+     */
+    private fun PdfFile.getCachedImage(page: ReaderPage): Observable<ReaderPage> {
+        val imageUrl = page.imageUrl ?: return Observable.just(page)
+
+        return Observable.just(page)
+            .flatMap {
+                if (!chapterCache.isImageInCache(imageUrl)) {
+                    cacheImage(page)
+                } else {
+                    Observable.just(page)
+                }
+            }
+            .doOnNext {
+                page.stream = { chapterCache.getImageFile(imageUrl).inputStream() }
+                page.status = Page.READY
+            }
+            .doOnError { page.status = Page.ERROR }
+            .onErrorReturn { page }
+    }
+
+    /**
+     * Returns an observable of the page that downloads the image to [ChapterCache].
+     *
+     * @param page the page.
+     */
+    private fun PdfFile.cacheImage(page: ReaderPage): Observable<ReaderPage> {
+        page.status = Page.DOWNLOAD_IMAGE
+        return Observable.just(getInputStream(page.index))
+            .doOnNext { chapterCache.putImageToCache(page.imageUrl!!, it) }
+            .map { page }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -92,6 +92,7 @@ class ChapterLoader(
                         error(context.getString(R.string.loader_rar5_error))
                     }
                     is LocalSource.Format.Epub -> EpubPageLoader(format.file)
+                    is LocalSource.Format.Pdf -> CachedPdfPageLoader(format.file, chapter)
                 }
             }
             source is SourceManager.StubSource -> throw source.getSourceNotInstalledException()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PdfPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PdfPageLoader.kt
@@ -1,0 +1,54 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.util.storage.PdfFile
+import rx.Observable
+import java.io.File
+
+/**
+ * Loader used to load a chapter from a .pdf file.
+ */
+class PdfPageLoader(file: File) : PageLoader() {
+
+    /**
+     * The pdf file.
+     */
+    private val pdf = PdfFile(file)
+
+    /**
+     * Recycles this loader and the pdf.
+     */
+    override fun recycle() {
+        super.recycle()
+        pdf.close()
+    }
+
+    /**
+     * Returns an observable containing the pages found on this pdf.
+     */
+    override fun getPages(): Observable<List<ReaderPage>> {
+        return pdf.getImagesFromPages()
+            .map { index ->
+                val streamFn = { pdf.getInputStream(index) }
+                ReaderPage(index = index).apply {
+                    stream = streamFn
+                    status = Page.READY
+                }
+            }
+            .let { Observable.just(it) }
+    }
+
+    /**
+     * Returns an observable that emits a ready state unless the loader was recycled.
+     */
+    override fun getPage(page: ReaderPage): Observable<Int> {
+        return Observable.just(
+            if (isRecycled) {
+                Page.ERROR
+            } else {
+                Page.READY
+            },
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -14,7 +14,9 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.ImageUtil
+import eu.kanade.tachiyomi.util.system.logcat
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
+import logcat.LogPriority
 import rx.Observable
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -216,6 +218,7 @@ class PagerPageHolder(
                     itemStream.close()
                 }
             }
+            .doOnError { logcat(LogPriority.WARN, it) { "Cannot load page." } }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnNext { (bais, isAnimated, background) ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -20,6 +20,8 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.dpToPx
+import eu.kanade.tachiyomi.util.system.logcat
+import logcat.LogPriority
 import rx.Observable
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -253,6 +255,7 @@ class WebtoonPageHolder(
 
                 ImageUtil.isAnimatedAndSupported(stream)
             }
+            .doOnError { logcat(LogPriority.WARN, it) { "Cannot load page." } }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnNext { isAnimated ->

--- a/app/src/main/java/eu/kanade/tachiyomi/util/storage/PdfFile.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/storage/PdfFile.kt
@@ -1,0 +1,69 @@
+package eu.kanade.tachiyomi.util.storage
+
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.graphics.pdf.PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY
+import android.os.ParcelFileDescriptor
+import android.os.ParcelFileDescriptor.MODE_READ_ONLY
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Read pdf as a list of png.
+ */
+class PdfFile(file: File) : Closeable {
+
+    /**
+     * The pdf renderer.
+     */
+    private val renderer = PdfRenderer(ParcelFileDescriptor.open(file, MODE_READ_ONLY))
+
+    /**
+     * Lock to read one page at a time.
+     */
+    private val lock = ReentrantLock()
+
+    /**
+     * Closes the underlying pdf file.
+     */
+    override fun close() {
+        renderer.close()
+    }
+
+    /**
+     * Returns an input stream for reading the contents of the specified pdf page.
+     */
+    fun getInputStream(index: Int): InputStream {
+        // only one page can be read at a time
+        return lock.withLock {
+            renderer.openPage(index).use { openPage ->
+                val bitmap =
+                    Bitmap.createBitmap(
+                        openPage.width,
+                        openPage.height,
+                        Bitmap.Config.ARGB_8888,
+                    )
+
+                openPage.render(bitmap, null, null, RENDER_MODE_FOR_DISPLAY)
+
+                ByteArrayOutputStream().use {
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+                    bitmap.recycle()
+                    ByteArrayInputStream(it.toByteArray())
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the path of all the images found in the pdf file.
+     */
+    fun getImagesFromPages(): List<Int> {
+        return (0 until renderer.pageCount).toList()
+    }
+}


### PR DESCRIPTION
I saw that issues were reported for pdf: https://github.com/tachiyomiorg/tachiyomi/issues/1751
I hope is implementation can answer to it :) 

Android lets us read a pdf though the object PdfRenderer.
This renderer transforms pdf pages to Bitmaps.

With that, two PageLoader were created:
1. PdfPageLoader: that streams pdf pages to pngs
2. CachedPdfPageLoader: that writes pdf pages to pngs in the cache (like HttpPageLoader)

Rendering pdf can be slow, so having the page cached gives a better experience.
PdfRenderer can only render one page at a time.

Also, the pdf pages are encoded a pngs, because [image-decoder](https://github.com/tachiyomiorg/image-decoder) cannot read bitmaps directly.
So maybe if it could, encoded and decoded pngs could be skipped and the streaming of pdf could be faster.

I'm open to feedbacks and to do further development on this feature :)