### PR TITLE
Add action to copy tags to clipboard

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -72,6 +72,7 @@ import eu.kanade.tachiyomi.ui.manga.ChapterItem
 import eu.kanade.tachiyomi.ui.manga.MangaScreenState
 import eu.kanade.tachiyomi.ui.manga.chapterDecimalFormat
 import eu.kanade.tachiyomi.util.lang.toRelativeString
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
 import java.text.DateFormat
@@ -117,6 +118,15 @@ fun MangaScreen(
     onAllChapterSelected: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val onClickCopyTags: () -> Unit = {
+        val tags = state.manga.genre
+        if (!tags.isNullOrEmpty()) {
+            val tagString = tags.joinToString()
+            context.copyToClipboard(tagString, tagString)
+        }
+    }
+
     if (!isTabletUi) {
         MangaScreenSmallImpl(
             state = state,
@@ -135,6 +145,7 @@ fun MangaScreen(
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
+            onClickCopyTags = onClickCopyTags,
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
             onDownloadActionClicked = onDownloadActionClicked,
@@ -166,6 +177,7 @@ fun MangaScreen(
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
+            onClickCopyTags = onClickCopyTags,
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
             onDownloadActionClicked = onDownloadActionClicked,
@@ -200,6 +212,7 @@ private fun MangaScreenSmallImpl(
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
+    onClickCopyTags: () -> Unit,
 
     // For cover dialog
     onCoverClicked: () -> Unit,
@@ -259,6 +272,7 @@ private fun MangaScreenSmallImpl(
                 onClickDownload = onDownloadActionClicked,
                 onClickEditCategory = onEditCategoryClicked,
                 onClickMigrate = onMigrateClicked,
+                onClickCopyTags = onClickCopyTags,
                 actionModeCounter = chapters.count { it.selected },
                 onSelectAll = { onAllChapterSelected(true) },
                 onInvertSelection = { onInvertSelection() },
@@ -411,6 +425,7 @@ fun MangaScreenLargeImpl(
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
+    onClickCopyTags: () -> Unit,
 
     // For cover dialog
     onCoverClicked: () -> Unit,
@@ -474,6 +489,7 @@ fun MangaScreenLargeImpl(
                     onClickDownload = onDownloadActionClicked,
                     onClickEditCategory = onEditCategoryClicked,
                     onClickMigrate = onMigrateClicked,
+                    onClickCopyTags = onClickCopyTags,
                     actionModeCounter = chapters.count { it.selected },
                     onSelectAll = { onAllChapterSelected(true) },
                     onInvertSelection = { onInvertSelection() },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -45,6 +45,7 @@ fun MangaToolbar(
     onClickDownload: ((DownloadAction) -> Unit)?,
     onClickEditCategory: (() -> Unit)?,
     onClickMigrate: (() -> Unit)?,
+    onClickCopyTags: (() -> Unit)?,
     // For action mode
     actionModeCounter: Int,
     onSelectAll: () -> Unit,
@@ -109,7 +110,7 @@ fun MangaToolbar(
                         Icon(Icons.Outlined.FilterList, contentDescription = stringResource(R.string.action_filter), tint = filterTint)
                     }
 
-                    if (onClickEditCategory != null || onClickMigrate != null || onClickShare != null) {
+                    if (onClickEditCategory != null || onClickMigrate != null || onClickShare != null || onClickCopyTags != null) {
                         OverflowMenu { closeMenu ->
                             if (onClickEditCategory != null) {
                                 DropdownMenuItem(
@@ -134,6 +135,15 @@ fun MangaToolbar(
                                     text = { Text(text = stringResource(R.string.action_share)) },
                                     onClick = {
                                         onClickShare()
+                                        closeMenu()
+                                    },
+                                )
+                            }
+                            if (onClickCopyTags != null) {
+                                DropdownMenuItem(
+                                    text = { Text(text = stringResource(R.string.action_copy_tags)) },
+                                    onClick = {
+                                        onClickCopyTags()
                                         closeMenu()
                                     },
                                 )

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="action_resume">Resume</string>
     <string name="action_open_in_browser">Open in browser</string>
     <string name="action_show_manga">Show entry</string>
+    <string name="action_copy_tags">Copy tags to clipboard</string>
     <!-- Do not translate "WebView" -->
     <string name="action_open_in_web_view">Open in WebView</string>
     <string name="action_web_view" translatable="false">WebView</string>


### PR DESCRIPTION
Implements #8382 

Detecting long press on Compose chips doesn't look straightforward. [source](https://stackoverflow.com/questions/74119839/detecting-long-press-events-on-chips-in-jetpack-compose).

I suggest we add new item in menu to copy tags.

### Images

<img src="https://user-images.githubusercontent.com/123292609/217603430-f89e9b10-0bde-42ce-81cb-ce3542a10cba.jpg" width="300">

<img src="https://user-images.githubusercontent.com/123292609/217603458-164d7bae-9116-49bc-95e0-cf50f2adfb8a.jpg" width="300">

