### PR TITLE
Adjust source filter list height

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceFilterSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceFilterSheet.kt
@@ -5,6 +5,8 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnLayout
+import androidx.recyclerview.widget.RecyclerView
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.kanade.tachiyomi.databinding.SourceFilterSheetBinding
@@ -54,6 +56,12 @@ class SourceFilterSheet(
         init {
             recycler.adapter = adapter
             recycler.setHasFixedSize(true)
+            recycler.doOnLayout {
+                val mRecyclerView = it as RecyclerView
+                val params = mRecyclerView.layoutParams
+                params.height = mRecyclerView.height + 240
+                mRecyclerView.layoutParams = params
+            }
             (binding.root.getChildAt(1) as ViewGroup).addView(recycler)
             addView(binding.root)
             binding.filterBtn.setOnClickListener { onFilterClicked() }


### PR DESCRIPTION
Fixes #4967 

Adding extra height to filter list so when a category is expanded the options will be visible.

### Images

<p float="left">
<img src="https://user-images.githubusercontent.com/123292609/218940694-b340181e-b5d5-439c-a54c-8d743ec6c892.jpg" width=300 style="margin: 100px;">
&nbsp;
<img src="https://user-images.githubusercontent.com/123292609/218940699-9f8d34e7-963f-4248-afb6-89f54db311f5.jpg" width=300>

</p>

