### PR TITLE
BrowseSource: do networkToLocal and initializeManga inside flow

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -54,7 +54,6 @@ import tachiyomi.domain.chapter.interactor.GetChapterByMangaId
 import tachiyomi.domain.chapter.interactor.SetMangaDefaultChapterFlags
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
-import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.toMangaUpdate
@@ -74,7 +73,6 @@ class BrowseSourceScreenModel(
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val coverCache: CoverCache = Injekt.get(),
     private val getRemoteManga: GetRemoteManga = Injekt.get(),
-    private val getManga: GetManga = Injekt.get(),
     private val getDuplicateLibraryManga: GetDuplicateLibraryManga = Injekt.get(),
     private val getCategories: GetCategories = Injekt.get(),
     private val getChapterByMangaId: GetChapterByMangaId = Injekt.get(),


### PR DESCRIPTION
during browsing of a source, after finishing the query for list of mangas for a given page
the networkToLocalManga is essentially called one by one (serially),
and only after that getManga.subscribe creates flow for each manga

the problem is that networkToLocalManga is relatively slow when inserting into database,
consequently only after all entries are committed into DB (slow) and flows are created (fast)
the new page can be requested

with this change the flow for each manga is created right after the list is loaded,
such that networkToLocalManga, filtering and initializeManga happen inside individual flows,
this allows much faster response to user actions (e.g. when reaching the end of current page,
new page is requested much faster, also each flow can be cancelled when out of view of user)
