### PR TITLE
Fallback chapter name if it ends up as blank

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -138,12 +138,33 @@ class DownloadProvider(
      * @param chapterScanlator scanlator of the chapter to query
      */
     fun getChapterDirName(chapterName: String, chapterScanlator: String?): String {
+        val newChapterName = getNewChapterName(chapterName)
         return DiskUtil.buildValidFilename(
             when {
-                chapterScanlator.isNullOrBlank().not() -> "${chapterScanlator}_$chapterName"
-                else -> chapterName
+                chapterScanlator.isNullOrBlank().not() -> "${chapterScanlator}_$newChapterName"
+                else -> newChapterName
             },
         )
+    }
+
+    /**
+     * Return the new name for the chapter (in case it's only a number or blanck)
+     *
+     * @param chapterName the name of the chapter
+     */
+    private fun getNewChapterName(chapterName: String): String {
+        var newChapterName = chapterName
+        try {
+            val chapterToInt = Integer.parseInt(chapterName)
+            if (chapterToInt.toString() == chapterName) {
+                newChapterName = "${R.string.chapter} $chapterName"
+            }
+        } catch (e: NumberFormatException) {
+            if (chapterName.isBlank()) {
+                newChapterName = "${R.string.chapter}"
+            }
+        }
+        return newChapterName
     }
 
     fun isChapterDirNameChanged(oldChapter: Chapter, newChapter: Chapter): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -138,7 +138,7 @@ class DownloadProvider(
      * @param chapterScanlator scanlator of the chapter to query
      */
     fun getChapterDirName(chapterName: String, chapterScanlator: String?): String {
-        val newChapterName = getNewChapterName(chapterName)
+        val newChapterName = sanitizeChapterName(chapterName)
         return DiskUtil.buildValidFilename(
             when {
                 chapterScanlator.isNullOrBlank().not() -> "${chapterScanlator}_$newChapterName"
@@ -152,11 +152,9 @@ class DownloadProvider(
      *
      * @param chapterName the name of the chapter
      */
-    private fun getNewChapterName(chapterName: String): String {
-        return if (chapterName.isEmpty() || chapterName.isBlank()) {
+    private fun sanitizeChapterName(chapterName: String): String {
+        return chapterName.ifBlank {
             "Chapter"
-        } else {
-            chapterName
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -148,23 +148,16 @@ class DownloadProvider(
     }
 
     /**
-     * Return the new name for the chapter (in case it's only a number or blanck)
+     * Return the new name for the chapter (in case it's empty or blank)
      *
      * @param chapterName the name of the chapter
      */
     private fun getNewChapterName(chapterName: String): String {
-        var newChapterName = chapterName
-        try {
-            val chapterToInt = Integer.parseInt(chapterName)
-            if (chapterToInt.toString() == chapterName) {
-                newChapterName = "${R.string.chapter} $chapterName"
-            }
-        } catch (e: NumberFormatException) {
-            if (chapterName.isBlank()) {
-                newChapterName = "${R.string.chapter}"
-            }
+        return if (chapterName.isEmpty() || chapterName.isBlank()) {
+            "Chapter"
+        } else {
+            chapterName
         }
-        return newChapterName
     }
 
     fun isChapterDirNameChanged(oldChapter: Chapter, newChapter: Chapter): Boolean {

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -446,7 +446,6 @@
     <string name="save_chapter_as_cbz">Save as CBZ archive</string>
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
-    <string name="chapter">Chapter</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -446,6 +446,7 @@
     <string name="save_chapter_as_cbz">Save as CBZ archive</string>
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
+    <string name="chapter">Chapter</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>


### PR DESCRIPTION
fix #8810 

Summary :
I changed the directory name when we download a manga which chapters name only composed of numbers or spaces.
It will appear like "Chapter 5" instead of "5" in the download directory.

