### PR TITLE
Allow option to skip duplicate chapters when downloading multiple chapters

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -60,6 +60,10 @@ object SettingsDownloadScreen : SearchableSettings {
                 title = stringResource(R.string.split_tall_images),
                 subtitle = stringResource(R.string.split_tall_images_summary),
             ),
+            Preference.PreferenceItem.SwitchPreference(
+                pref = downloadPreferences.skipDupe(),
+                title = stringResource(R.string.pref_skip_dupe_chapters),
+            ),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,
                 categories = allCategories,

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -16,6 +16,8 @@ class DownloadPreferences(
 
     fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", false)
 
+    fun skipDupe() = preferenceStore.getBoolean("pref_download_skip_dupe", false)
+
     fun autoDownloadWhileReading() = preferenceStore.getInt("auto_download_while_reading", 0)
 
     fun removeAfterReadSlots() = preferenceStore.getInt("remove_after_read_slots", -1)


### PR DESCRIPTION
Closes: #9328 

### Feature Description
Adds a new option in settings that skips duplicate chapters when downloading multiple chapters. For example, if this setting is enabled, when downloading the next 5 chapters, it will download the next 5 unique chapters, and skips over duplicate chapters if there is any.

The logic for this is the same as the current "Skip Duplicate Chapter" option for the reader. It grabs all chapters that are valid for downloading (unless the chapter list is already picked by the user) and groups them by chapter number. Then we loop through each chapter number and grab the first chapter with the same scanlator group as the first chapter in the list (or the first chapter, if none is found).

Demo: https://streamable.com/zelz6h