### PR TITLE
Remove horizontal padding of actions row in empty screen

### DIFF
--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -81,8 +81,6 @@ fun EmptyScreen(
                 modifier = Modifier
                     .padding(
                         top = 24.dp,
-                        start = 24.dp,
-                        end = 24.dp,
                     ),
                 horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
             ) {


### PR DESCRIPTION
Fixes #9281

Was able to reproduce this issue on my device only after adding some extra 'w' to UI string. 

### Images
| after | before |
| ------- | ------- |
| ![after](https://user-images.githubusercontent.com/123292609/231961616-ca2feca0-9c58-4aea-bcd4-ada2cf556e13.jpg) | ![before](https://user-images.githubusercontent.com/123292609/231961631-62d00020-777b-4bec-be9c-dd30a14aed2a.jpg) |
