### PR TITLE
Changed the string so that the scanlator appears on a new line

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderTransitionView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderTransitionView.kt
@@ -64,8 +64,7 @@ class ReaderTransitionView @JvmOverloads constructor(context: Context, attrs: At
                 bold { append(context.getString(R.string.transition_previous)) }
                 append("\n${prevChapter.name}")
                 if (!prevChapter.scanlator.isNullOrBlank()) {
-                    append(DOT_SEPERATOR)
-                    append("${prevChapter.scanlator}")
+                    append("\n${prevChapter.scanlator}")
                 }
                 if (isPrevDownloaded) addDLImageSpan()
             }
@@ -73,8 +72,7 @@ class ReaderTransitionView @JvmOverloads constructor(context: Context, attrs: At
                 bold { append(context.getString(R.string.transition_current)) }
                 append("\n${transition.from.chapter.name}")
                 if (!transition.from.chapter.scanlator.isNullOrBlank()) {
-                    append(DOT_SEPERATOR)
-                    append("${transition.from.chapter.scanlator}")
+                    append("\n${transition.from.chapter.scanlator}")
                 }
                 if (isCurrentDownloaded) addDLImageSpan()
             }


### PR DESCRIPTION
<!--
 
  
  If your changes are visual, please provide images below:

### Images
| ![Screenshot_20230420_135139_eu kanade tachiyomi](https://user-images.githubusercontent.com/99197171/233418869-1bc89595-07ec-42ba-954c-a83a710ee98e.jpg) |![Screenshot_20230420_135218_eu kanade tachiyomiDlkn debug](https://user-images.githubusercontent.com/99197171/233419028-4d45ed7c-a8e7-4b27-90e9-3c53554a3374.jpg) |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

Changed both transition page's strings so that scanlators are on another line

 _close_ #9216 

| ![Screenshot_20230420_135139_eu kanade tachiyomi](https://user-images.githubusercontent.com/99197171/233418869-1bc89595-07ec-42ba-954c-a83a710ee98e.jpg) |![Screenshot_20230420_135218_eu kanade tachiyomiDlkn debug](https://user-images.githubusercontent.com/99197171/233419028-4d45ed7c-a8e7-4b27-90e9-3c53554a3374.jpg) |
| ------- | ------- |
