### PR TITLE
Populate the ComicInfo Number field with chapter numbers

### DIFF
--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -98,6 +98,7 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
+    number = ComicInfo.Number(chapter.chapterNumber.toString()),
     web = ComicInfo.Web(chapterUrl),
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -98,7 +98,7 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
-    number = ComicInfo.Number(chapter.chapterNumber.toString()),
+    number = chapter.chapterNumber.takeIf { it >= 0 }?.let { ComicInfo.Number(it.toString()) },
     web = ComicInfo.Web(chapterUrl),
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -44,6 +44,7 @@ fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
 data class ComicInfo(
     val title: Title?,
     val series: Series?,
+    val number: Number?,
     val summary: Summary?,
     val writer: Writer?,
     val penciller: Penciller?,
@@ -74,6 +75,10 @@ data class ComicInfo(
     @Serializable
     @XmlSerialName("Series", "", "")
     data class Series(@XmlValue(true) val value: String = "")
+
+    @Serializable
+    @XmlSerialName("Number", "", "")
+    data class Number(@XmlValue(true) val value: String = "")
 
     @Serializable
     @XmlSerialName("Summary", "", "")


### PR DESCRIPTION
Populate the Number field of ComicInfo files with chapter numbers.  

According to the [Official ComicInfo documentation](https://anansi-project.github.io/docs/comicinfo/documentation), [Kavita's documentation](https://wiki.kavitareader.com/en/archive/guides/metadata) and [Komga's documentation](https://komga.org/guides/scan-analysis-refresh.html#import-metadata-for-cbr-cbz-containing-a-comicinfo-xml-file) (only tested with Komga)

