### PR TITLE
Cleanup MangaScreenModel successState usage

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -134,7 +134,7 @@ class MangaScreen(
         )
 
         val onDismissRequest = { screenModel.dismissDialog() }
-        when (val dialog = (state as? MangaScreenState.Success)?.dialog) {
+        when (val dialog = successState.dialog) {
             null -> {}
             is MangaInfoScreenModel.Dialog.ChangeCategory -> {
                 ChangeCategoryDialog(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -283,12 +283,7 @@ class MangaInfoScreenModel(
                     val duplicate = getDuplicateLibraryManga.await(manga.title)
 
                     if (duplicate != null) {
-                        mutableState.update { state ->
-                            when (state) {
-                                MangaScreenState.Loading -> state
-                                is MangaScreenState.Success -> state.copy(dialog = Dialog.DuplicateManga(manga, duplicate))
-                            }
-                        }
+                        updateSuccessState { it.copy(dialog = Dialog.DuplicateManga(manga, duplicate)) }
                         return@launchIO
                     }
                 }
@@ -345,16 +340,13 @@ class MangaInfoScreenModel(
         coroutineScope.launch {
             val categories = getCategories()
             val selection = getMangaCategoryIds(manga)
-            mutableState.update { state ->
-                when (state) {
-                    MangaScreenState.Loading -> state
-                    is MangaScreenState.Success -> state.copy(
-                        dialog = Dialog.ChangeCategory(
-                            manga = manga,
-                            initialSelection = categories.mapAsCheckboxState { it.id in selection },
-                        ),
-                    )
-                }
+            updateSuccessState { successState ->
+                successState.copy(
+                    dialog = Dialog.ChangeCategory(
+                        manga = manga,
+                        initialSelection = categories.mapAsCheckboxState { it.id in selection },
+                    ),
+                )
             }
         }
     }
@@ -959,52 +951,23 @@ class MangaInfoScreenModel(
     }
 
     fun dismissDialog() {
-        mutableState.update { state ->
-            when (state) {
-                MangaScreenState.Loading -> state
-                is MangaScreenState.Success -> state.copy(dialog = null)
-            }
-        }
+        updateSuccessState { it.copy(dialog = null) }
     }
 
     fun showDeleteChapterDialog(chapters: List<Chapter>) {
-        mutableState.update { state ->
-            when (state) {
-                MangaScreenState.Loading -> state
-                is MangaScreenState.Success -> state.copy(dialog = Dialog.DeleteChapters(chapters))
-            }
-        }
+        updateSuccessState { it.copy(dialog = Dialog.DeleteChapters(chapters)) }
     }
 
     fun showSettingsDialog() {
-        mutableState.update { state ->
-            when (state) {
-                MangaScreenState.Loading -> state
-                is MangaScreenState.Success -> state.copy(dialog = Dialog.SettingsSheet)
-            }
-        }
+        updateSuccessState { it.copy(dialog = Dialog.SettingsSheet) }
     }
 
     fun showTrackDialog() {
-        mutableState.update { state ->
-            when (state) {
-                MangaScreenState.Loading -> state
-                is MangaScreenState.Success -> {
-                    state.copy(dialog = Dialog.TrackSheet)
-                }
-            }
-        }
+        updateSuccessState { it.copy(dialog = Dialog.TrackSheet) }
     }
 
     fun showCoverDialog() {
-        mutableState.update { state ->
-            when (state) {
-                MangaScreenState.Loading -> state
-                is MangaScreenState.Success -> {
-                    state.copy(dialog = Dialog.FullCover)
-                }
-            }
-        }
+        updateSuccessState { it.copy(dialog = Dialog.FullCover) }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -135,8 +135,13 @@ class MangaInfoScreenModel(
     /**
      * Helper function to update the UI state only if it's currently in success state
      */
-    private fun updateSuccessState(func: (MangaScreenState.Success) -> MangaScreenState.Success) {
-        mutableState.update { if (it is MangaScreenState.Success) func(it) else it }
+    private inline fun updateSuccessState(func: (MangaScreenState.Success) -> MangaScreenState.Success) {
+        mutableState.update {
+            when (it) {
+                MangaScreenState.Loading -> it
+                is MangaScreenState.Success -> func(it)
+            }
+        }
     }
 
     init {


### PR DESCRIPTION
 - Refactor `updateSuccessState`
   - Convert to `inline` function
   - Use `when` for type safety if we add other `MangaScreenState` types
- Replace equivalent expressions with `updateSuccessState`
- Replace safe cast in `MangaScreen`