### PR TITLE
Automatically convert Details.json to ComicInfo.xml

### DIFF
--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -8,6 +8,25 @@ import nl.adaptivity.xmlutil.serialization.XmlValue
 
 const val COMIC_INFO_FILE = "ComicInfo.xml"
 
+fun SManga.getComicInfo() = ComicInfo(
+    series = ComicInfo.Series(title),
+    summary = description?.let { ComicInfo.Summary(it) },
+    writer = author?.let { ComicInfo.Writer(it) },
+    penciller = artist?.let { ComicInfo.Penciller(it) },
+    genre = genre?.let { ComicInfo.Genre(it) },
+    publishingStatus = ComicInfo.PublishingStatusTachiyomi(
+        ComicInfoPublishingStatus.toComicInfoValue(status.toLong()),
+    ),
+    title = null,
+    number = null,
+    web = null,
+    translator = null,
+    inker = null,
+    colorist = null,
+    letterer = null,
+    coverArtist = null,
+    tags = null,
+)
 fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
     comicInfo.series?.let { title = it.value }
     comicInfo.writer?.let { author = it.value }

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -27,6 +27,7 @@ fun SManga.getComicInfo() = ComicInfo(
     coverArtist = null,
     tags = null,
 )
+
 fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
     comicInfo.series?.let { title = it.value }
     comicInfo.writer?.let { author = it.value }


### PR DESCRIPTION
I noticed that there was an open todo for converting `Details.json` to `ComicInfo.xml`

We don't really have to delete the `Details.json` file since they won't be scanned as long as a `ComicInfo` file exists, but it could be confusing to users when changes they make to their `Details.json` files are not reflected by the app. Please tell me if they should not be deleted. 
