### PR TITLE
Better handle decimal chapter numbers and add categories in ComicInfo.xml files

### DIFF
--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -95,16 +95,22 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 /**
  * Creates a ComicInfo instance based on the manga and chapter metadata.
  */
-fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String) = ComicInfo(
+fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories: List<String>) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
-    number = chapter.chapterNumber.takeIf { it >= 0 }?.let { ComicInfo.Number(it.toString()) },
+    number = chapter.chapterNumber.takeIf { it >= 0 }?.let {
+        if ((it.rem(1) == 0.0F)) {
+            ComicInfo.Number(it.toInt().toString())
+        } else {
+            ComicInfo.Number(it.toString())
+        }
+    },
     web = ComicInfo.Web(chapterUrl),
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },
     translator = chapter.scanlator?.let { ComicInfo.Translator(it) },
-    genre = manga.genre?.let { ComicInfo.Genre(it.joinToString()) },
+    genre = manga.genre?.let { ComicInfo.Genre((it.plus(categories)).joinToString()) },
     publishingStatus = ComicInfo.PublishingStatusTachiyomi(
         ComicInfoPublishingStatus.toComicInfoValue(manga.status),
     ),

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -95,7 +95,7 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 /**
  * Creates a ComicInfo instance based on the manga and chapter metadata.
  */
-fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories: List<String>) = ComicInfo(
+fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories: List<String>?) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
     number = chapter.chapterNumber.takeIf { it >= 0 }?.let {
@@ -110,10 +110,11 @@ fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories:
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },
     translator = chapter.scanlator?.let { ComicInfo.Translator(it) },
-    genre = manga.genre?.let { ComicInfo.Genre((it.plus(categories)).joinToString()) },
+    genre = manga.genre?.let { ComicInfo.Genre(it.joinToString()) },
     publishingStatus = ComicInfo.PublishingStatusTachiyomi(
         ComicInfoPublishingStatus.toComicInfoValue(manga.status),
     ),
+    categories = categories?.let { ComicInfo.CategoriesTachiyomi(it.joinToString()) },
     inker = null,
     colorist = null,
     letterer = null,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -631,7 +631,7 @@ class Downloader(
         source: HttpSource,
     ) {
         val chapterUrl = source.getChapterUrl(chapter.toSChapter())
-        val categories = runBlocking { getCategories.await(manga.id) }.map { "$CATAGORY_SYMBOL ${it.name.trim()}" }
+        val categories = runBlocking { getCategories.await(manga.id) }.map { it.name.trim() }.takeUnless { it.isEmpty() }
         val comicInfo = getComicInfo(manga, chapter, chapterUrl, categories)
         // Remove the old file
         dir.findFile(COMIC_INFO_FILE)?.delete()
@@ -725,7 +725,6 @@ class Downloader(
         const val WARNING_NOTIF_TIMEOUT_MS = 30_000L
         const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
         private const val DOWNLOADS_QUEUED_WARNING_THRESHOLD = 30
-        private const val CATAGORY_SYMBOL = "\uD83D\uDD30"
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
 import logcat.LogPriority
 import nl.adaptivity.xmlutil.serialization.XML
@@ -624,14 +623,14 @@ class Downloader(
     /**
      * Creates a ComicInfo.xml file inside the given directory.
      */
-    private fun createComicInfoFile(
+    private suspend fun createComicInfoFile(
         dir: UniFile,
         manga: Manga,
         chapter: Chapter,
         source: HttpSource,
     ) {
         val chapterUrl = source.getChapterUrl(chapter.toSChapter())
-        val categories = runBlocking { getCategories.await(manga.id) }.map { it.name.trim() }.takeUnless { it.isEmpty() }
+        val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
         val comicInfo = getComicInfo(manga, chapter, chapterUrl, categories)
         // Remove the old file
         dir.findFile(COMIC_INFO_FILE)?.delete()

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -7,6 +7,7 @@ import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue
 
 const val COMIC_INFO_FILE = "ComicInfo.xml"
+private const val CATAGORY_SYMBOL = "\uD83D\uDD30"
 
 fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
     comicInfo.series?.let { title = it.value }
@@ -18,6 +19,12 @@ fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
         comicInfo.tags?.value,
     )
         .flatMap { it.split(", ") }
+        .plus(
+            listOfNotNull(comicInfo.categories?.value).flatMap {
+                it.split(", ")
+                    .map { category -> "$CATAGORY_SYMBOL $category" } 
+            },
+        )
         .distinct()
         .joinToString(", ") { it.trim() }
         .takeIf { it.isNotEmpty() }
@@ -57,6 +64,7 @@ data class ComicInfo(
     val tags: Tags?,
     val web: Web?,
     val publishingStatus: PublishingStatusTachiyomi?,
+    val categories: CategoriesTachiyomi?,
 ) {
     @Suppress("UNUSED")
     @XmlElement(false)
@@ -128,6 +136,10 @@ data class ComicInfo(
     @Serializable
     @XmlSerialName("PublishingStatusTachiyomi", "http://www.w3.org/2001/XMLSchema", "ty")
     data class PublishingStatusTachiyomi(@XmlValue(true) val value: String = "")
+
+    @Serializable
+    @XmlSerialName("Categories", "http://www.w3.org/2001/XMLSchema", "ty")
+    data class CategoriesTachiyomi(@XmlValue(true) val value: String = "")
 }
 
 enum class ComicInfoPublishingStatus(

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -7,7 +7,6 @@ import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue
 
 const val COMIC_INFO_FILE = "ComicInfo.xml"
-private const val CATAGORY_SYMBOL = "\uD83D\uDD30"
 
 fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
     comicInfo.series?.let { title = it.value }
@@ -17,14 +16,8 @@ fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
     listOfNotNull(
         comicInfo.genre?.value,
         comicInfo.tags?.value,
+        comicInfo.categories?.value,
     )
-        .flatMap { it.split(", ") }
-        .plus(
-            listOfNotNull(comicInfo.categories?.value).flatMap {
-                it.split(", ")
-                    .map { category -> "$CATAGORY_SYMBOL $category" }
-            },
-        )
         .distinct()
         .joinToString(", ") { it.trim() }
         .takeIf { it.isNotEmpty() }

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -22,7 +22,7 @@ fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
         .plus(
             listOfNotNull(comicInfo.categories?.value).flatMap {
                 it.split(", ")
-                    .map { category -> "$CATAGORY_SYMBOL $category" } 
+                    .map { category -> "$CATAGORY_SYMBOL $category" }
             },
         )
         .distinct()


### PR DESCRIPTION
1. Changed the serialized chapter numbers to not use decimal points if possible.

2. Add the library categories to the Manga genres with 🔰 as a prefix. 

Example output: 
<img src="https://github.com/tachiyomiorg/tachiyomi/assets/84282253/d64c0549-a718-41c6-99d5-ee7120fd2eab" width="340">
