### PR TITLE
Automatically mark new chapters as read if a duplicate chapter exists and has been read

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -269,6 +269,11 @@ object SettingsLibraryScreen : SearchableSettings {
                     pref = libraryPreferences.newShowUpdatesCount(),
                     title = stringResource(R.string.pref_library_update_show_tab_badge),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = libraryPreferences.libraryReadDuplicateChapters(),
+                    title = stringResource(R.string.pref_library_mark_duplicate_chapters),
+                    subtitle = stringResource(R.string.pref_library_mark_duplicate_chapters_summary),
+                ),
             ),
         )
     }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -38,6 +38,8 @@ class LibraryPreferences(
         ),
     )
 
+    fun libraryReadDuplicateChapters() = preferenceStore.getBoolean("pref_library_mark_duplicate_chapters", false)
+
     fun leadingExpectedDays() = preferenceStore.getInt("pref_library_before_expect_key", 1)
     fun followingExpectedDays() = preferenceStore.getInt("pref_library_after_expect_key", 1)
 

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -277,6 +277,8 @@
     <string name="pref_library_update_refresh_metadata_summary">Check for new cover and details when updating library</string>
     <string name="pref_library_update_refresh_trackers">Automatically refresh trackers</string>
     <string name="pref_library_update_refresh_trackers_summary">Update trackers when updating library</string>
+    <string name="pref_library_mark_duplicate_chapters">Mark new duplicate chapters as read</string>
+    <string name="pref_library_mark_duplicate_chapters_summary">Automatically mark new chapters as read if it has been read before</string>
 
     <string name="default_category">Default category</string>
     <string name="default_category_summary">Always ask</string>


### PR DESCRIPTION
Adds a toggle-able option to automatically mark new duplicate chapters (a new chapter with the same chapter number) as read if it has been read by the user before. This removes the need to manually mark new duplicate chapters as read to avoid skipping the manga when updating.