### PR TITLE
Add filters to Global search

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DoneAll
@@ -16,7 +17,6 @@ import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -115,7 +115,7 @@ fun GlobalSearchScreen(
                             )
                         },
                         label = {
-                            Text(text = stringResource(id = R.string.available))
+                            Text(text = stringResource(id = R.string.has_results))
                         },
                     )
                 }

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -1,7 +1,21 @@
 package eu.kanade.presentation.browse
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DoneAll
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.PushPin
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -16,19 +30,23 @@ import eu.kanade.presentation.browse.components.GlobalSearchResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchToolbar
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchFilter
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchState
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchItemResult
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.presentation.core.components.material.Divider
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.padding
 
 @Composable
 fun GlobalSearchScreen(
     state: GlobalSearchState,
+    items: Map<CatalogueSource, SearchItemResult>,
     navigateUp: () -> Unit,
     onChangeSearchQuery: (String?) -> Unit,
     onSearch: (String) -> Unit,
+    onChangeFilter: (GlobalSearchFilter) -> Unit,
     getManga: @Composable (Manga) -> State<Manga>,
     onClickSource: (CatalogueSource) -> Unit,
     onClickItem: (Manga) -> Unit,
@@ -36,19 +54,78 @@ fun GlobalSearchScreen(
 ) {
     Scaffold(
         topBar = { scrollBehavior ->
-            GlobalSearchToolbar(
-                searchQuery = state.searchQuery,
-                progress = state.progress,
-                total = state.total,
-                navigateUp = navigateUp,
-                onChangeSearchQuery = onChangeSearchQuery,
-                onSearch = onSearch,
-                scrollBehavior = scrollBehavior,
-            )
+            Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                GlobalSearchToolbar(
+                    searchQuery = state.searchQuery,
+                    progress = state.progress,
+                    total = state.total,
+                    navigateUp = navigateUp,
+                    onChangeSearchQuery = onChangeSearchQuery,
+                    onSearch = onSearch,
+                    scrollBehavior = scrollBehavior,
+                )
+
+                Row(
+                    modifier = Modifier
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = MaterialTheme.padding.small),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+                ) {
+                    FilterChip(
+                        selected = state.searchFilter == GlobalSearchFilter.All,
+                        onClick = { onChangeFilter(GlobalSearchFilter.All) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.DoneAll,
+                                contentDescription = "",
+                                modifier = Modifier
+                                    .size(FilterChipDefaults.IconSize),
+                            )
+                        },
+                        label = {
+                            Text(text = stringResource(id = R.string.all))
+                        },
+                    )
+
+                    FilterChip(
+                        selected = state.searchFilter == GlobalSearchFilter.PinnedOnly,
+                        onClick = { onChangeFilter(GlobalSearchFilter.PinnedOnly) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.PushPin,
+                                contentDescription = "",
+                                modifier = Modifier
+                                    .size(FilterChipDefaults.IconSize),
+                            )
+                        },
+                        label = {
+                            Text(text = stringResource(id = R.string.pinned_sources))
+                        },
+                    )
+
+                    FilterChip(
+                        selected = state.searchFilter == GlobalSearchFilter.AvailableOnly,
+                        onClick = { onChangeFilter(GlobalSearchFilter.AvailableOnly) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.FilterList,
+                                contentDescription = "",
+                                modifier = Modifier
+                                    .size(FilterChipDefaults.IconSize),
+                            )
+                        },
+                        label = {
+                            Text(text = stringResource(id = R.string.available))
+                        },
+                    )
+                }
+
+                Divider()
+            }
         },
     ) { paddingValues ->
         GlobalSearchContent(
-            items = state.items,
+            items = items,
             contentPadding = paddingValues,
             getManga = getManga,
             onClickSource = onClickSource,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -35,6 +35,7 @@ class GlobalSearchScreen(
         var showSingleLoadingScreen by remember {
             mutableStateOf(searchQuery.isNotEmpty() && extensionFilter.isNotEmpty() && state.total == 1)
         }
+        val filteredSources by screenModel.searchPagerFlow.collectAsState()
 
         if (showSingleLoadingScreen) {
             LoadingScreen()
@@ -57,10 +58,12 @@ class GlobalSearchScreen(
         } else {
             GlobalSearchScreen(
                 state = state,
+                items = filteredSources,
                 navigateUp = navigator::pop,
                 onChangeSearchQuery = screenModel::updateSearchQuery,
                 onSearch = screenModel::search,
                 getManga = { screenModel.getManga(it) },
+                onChangeFilter = screenModel::setFilter,
                 onClickSource = {
                     if (!screenModel.incognitoMode.get()) {
                         screenModel.lastUsedSourceId.set(it.id)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -3,7 +3,12 @@ package eu.kanade.tachiyomi.ui.browse.source.globalsearch
 import androidx.compose.runtime.Immutable
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.source.CatalogueSource
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
@@ -19,6 +24,19 @@ class GlobalSearchScreenModel(
 
     val incognitoMode = preferences.incognitoMode()
     val lastUsedSourceId = sourcePreferences.lastUsedSource()
+
+    val searchPagerFlow = state.map { Pair(it.searchFilter, it.items) }
+        .distinctUntilChanged()
+        .map { (filter, items) ->
+            items
+                .filterNot { (_, result) ->
+                    filter == GlobalSearchFilter.AvailableOnly &&
+                        result is SearchItemResult.Error
+                }
+                .filterNot { (source, _) ->
+                    filter == GlobalSearchFilter.PinnedOnly && "${source.id}" !in sourcePreferences.pinnedSources().get()
+                }
+        }.stateIn(ioCoroutineScope, SharingStarted.Lazily, state.value.items)
 
     init {
         extensionFilter = initialExtensionFilter
@@ -50,14 +68,22 @@ class GlobalSearchScreenModel(
         }
     }
 
+    fun setFilter(filter: GlobalSearchFilter) {
+        mutableState.update { it.copy(searchFilter = filter) }
+    }
+
     override fun getItems(): Map<CatalogueSource, SearchItemResult> {
         return mutableState.value.items
     }
+}
+enum class GlobalSearchFilter {
+    All, PinnedOnly, AvailableOnly
 }
 
 @Immutable
 data class GlobalSearchState(
     val searchQuery: String? = null,
+    val searchFilter: GlobalSearchFilter = GlobalSearchFilter.All,
     val items: Map<CatalogueSource, SearchItemResult> = emptyMap(),
 ) {
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -52,7 +52,7 @@ class GlobalSearchScreenModel(
 
     private fun isSourceVisible(filter: GlobalSearchFilter, source: CatalogueSource, result: SearchItemResult): Boolean {
         return when (filter) {
-            GlobalSearchFilter.AvailableOnly -> result !is SearchItemResult.Error
+            GlobalSearchFilter.AvailableOnly -> result is SearchItemResult.Success && !result.isEmpty
             GlobalSearchFilter.PinnedOnly -> "${source.id}" in sourcePreferences.pinnedSources().get()
             GlobalSearchFilter.All -> true
         }
@@ -78,6 +78,7 @@ class GlobalSearchScreenModel(
         return mutableState.value.items
     }
 }
+
 enum class GlobalSearchFilter {
     All, PinnedOnly, AvailableOnly
 }

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -633,6 +633,7 @@
     <string name="latest">Latest</string>
     <string name="popular">Popular</string>
     <string name="browse">Browse</string>
+    <string name="available">Available</string>
     <string name="local_source_help_guide">Local source guide</string>
     <string name="no_pinned_sources">You have no pinned sources</string>
     <string name="chapter_not_found">Chapter not found</string>

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -633,7 +633,7 @@
     <string name="latest">Latest</string>
     <string name="popular">Popular</string>
     <string name="browse">Browse</string>
-    <string name="available">Available</string>
+    <string name="has_results">Has results</string>
     <string name="local_source_help_guide">Local source guide</string>
     <string name="no_pinned_sources">You have no pinned sources</string>
     <string name="chapter_not_found">Chapter not found</string>


### PR DESCRIPTION
### Summary
Related issue #6654

Added a few filter chips to the global search to quickly filter the results
- **All** : Shows all sources
- **Pinned**: Shows only pinned sources
- **available**: Hides sources that have an error (Failed to bypass cloudflare ...) 

### Implementation
For the implementation process I used Filterchips so I followed the way it was used in the `BrowseSourceScreen` class.
But I'm unsure if this is the best way to create the filters (using an enum)
Also for the 'available' icon I'm not sure what icon to use.

### Images
| All | Pinned | Available |
| ------- | ------- |  ------- |
| ![all](https://github.com/tachiyomiorg/tachiyomi/assets/46049558/d74cd01e-be55-4922-aca6-70b54d53bb10) | ![Pinned](https://github.com/tachiyomiorg/tachiyomi/assets/46049558/db64105e-fa93-4dfa-a3a9-542df76b044a) | ![Available](https://github.com/tachiyomiorg/tachiyomi/assets/46049558/bf6be77a-1cf3-4898-9fd0-c08352a9f3f5) |
