### PR TITLE
Fix to multiple chapter download incorrect state

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -149,7 +149,8 @@ class MangaInfoScreenModel(
             combine(
                 getMangaAndChapters.subscribe(mangaId).distinctUntilChanged(),
                 downloadCache.changes,
-            ) { mangaAndChapters, _ -> mangaAndChapters }
+                downloadManager.queueState,
+            ) { mangaAndChapters, _, _ -> mangaAndChapters }
                 .collectLatest { (manga, chapters) ->
                     updateSuccessState {
                         it.copy(


### PR DESCRIPTION
### Summary

Closes #9577

The problem is that the queued chapters don't get updated visually until one chapter finishes downloading.

From my understanding, the issue is caused because the chapters aren't reloaded until the downlodcache issues changes, which is when the download finishes for a chapter.
Adding a subscribtion to the downloadmanager's queue state fixes the issue.

