### PR TITLE
Added In-app list for failed library updates

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Label
 import androidx.compose.material.icons.outlined.RemoveDone
+import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -300,6 +301,63 @@ fun LibraryBottomActionMenu(
                     toConfirm = confirm[4],
                     onLongClick = { onLongClickItem(4) },
                     onClick = onDeleteClicked,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FailedUpdatesBottomActionMenu(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    onDeleteClicked: () -> Unit,
+    onDismissClicked: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = expandVertically(animationSpec = tween(delayMillis = 300)),
+        exit = shrinkVertically(animationSpec = tween()),
+    ) {
+        val scope = rememberCoroutineScope()
+        Surface(
+            modifier = modifier,
+            shape = MaterialTheme.shapes.large.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+            tonalElevation = 3.dp,
+        ) {
+            val haptic = LocalHapticFeedback.current
+            val confirm = remember { mutableStateListOf(false, false) }
+            var resetJob: Job? = remember { null }
+            val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                (0..<2).forEach { i -> confirm[i] = i == toConfirmIndex }
+                resetJob?.cancel()
+                resetJob = scope.launch {
+                    delay(1.seconds)
+                    if (isActive) confirm[toConfirmIndex] = false
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .windowInsetsPadding(
+                        WindowInsets.navigationBars
+                            .only(WindowInsetsSides.Bottom),
+                    )
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+            ) {
+                Button(
+                    title = stringResource(R.string.action_delete),
+                    icon = Icons.Outlined.Delete,
+                    toConfirm = confirm[0],
+                    onLongClick = { onLongClickItem(0) },
+                    onClick = onDeleteClicked,
+                )
+                Button(
+                    title = "Dismiss",
+                    icon = Icons.Outlined.VisibilityOff,
+                    toConfirm = confirm[1],
+                    onLongClick = { onLongClickItem(1) },
+                    onClick = onDismissClicked,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -47,6 +49,7 @@ fun UpdateScreen(
     onSelectAll: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
     onUpdateLibrary: () -> Boolean,
+    onUpdateWarning: () -> Unit,
     onDownloadChapter: (List<UpdatesItem>, ChapterDownloadAction) -> Unit,
     onMultiBookmarkClicked: (List<UpdatesItem>, bookmark: Boolean) -> Unit,
     onMultiMarkAsReadClicked: (List<UpdatesItem>, read: Boolean) -> Unit,
@@ -62,6 +65,7 @@ fun UpdateScreen(
         topBar = { scrollBehavior ->
             UpdatesAppBar(
                 onUpdateLibrary = { onUpdateLibrary() },
+                onUpdateWarning = onUpdateWarning,
                 actionModeCounter = state.selected.size,
                 onSelectAll = { onSelectAll(true) },
                 onInvertSelection = { onInvertSelection() },
@@ -127,10 +131,13 @@ fun UpdateScreen(
     }
 }
 
+private val warningIconEnabled = mutableStateOf(false)
+
 @Composable
 private fun UpdatesAppBar(
     modifier: Modifier = Modifier,
     onUpdateLibrary: () -> Unit,
+    onUpdateWarning: () -> Unit,
     // For action mode
     actionModeCounter: Int,
     onSelectAll: () -> Unit,
@@ -138,19 +145,26 @@ private fun UpdatesAppBar(
     onCancelActionMode: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
+    val warningIconTint = MaterialTheme.colorScheme.error
     AppBar(
         modifier = modifier,
         title = stringResource(R.string.label_recent_updates),
         actions = {
-            AppBarActions(
-                listOf(
-                    AppBar.Action(
-                        title = stringResource(R.string.action_update_library),
-                        icon = Icons.Outlined.Refresh,
-                        onClick = onUpdateLibrary,
-                    ),
-                ),
+            val actions = mutableListOf<AppBar.Action>()
+            if (warningIconEnabled.value) { // only add the warning icon if it is enabled
+                actions += AppBar.Action(
+                    title = "Update Warning",
+                    icon = Icons.Rounded.Warning,
+                    onClick = onUpdateWarning,
+                    iconTint = warningIconTint,
+                )
+            }
+            actions += AppBar.Action(
+                title = stringResource(R.string.action_update_library),
+                icon = Icons.Outlined.Refresh,
+                onClick = onUpdateLibrary,
             )
+            AppBarActions(actions)
         },
         actionModeCounter = actionModeCounter,
         onCancelActionMode = onCancelActionMode,
@@ -211,4 +225,8 @@ private fun UpdatesBottomBar(
 sealed interface UpdatesUiModel {
     data class Header(val date: String) : UpdatesUiModel
     data class Item(val item: UpdatesItem) : UpdatesUiModel
+}
+
+fun setWarningIconEnabled(enabled: Boolean) {
+    warningIconEnabled.value = enabled
 }

--- a/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesContent.kt
@@ -1,0 +1,386 @@
+package eu.kanade.presentation.updates.failed
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.MaterialTheme.typography
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.outlined.FlightTakeoff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastAny
+import androidx.core.graphics.drawable.toBitmap
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.extension.ExtensionManager
+import eu.kanade.tachiyomi.util.system.LocaleHelper
+import tachiyomi.domain.source.model.Source
+import tachiyomi.presentation.core.components.FastScrollLazyColumn
+import tachiyomi.presentation.core.components.Pill
+import tachiyomi.presentation.core.components.material.TextButton
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.util.secondaryItemAlpha
+import tachiyomi.presentation.core.util.selectedBackground
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+fun LazyListScope.downloadStatUiItems(
+    items: List<FailedUpdatesManga>,
+    selectionMode: Boolean,
+    onSelected: (FailedUpdatesManga, Boolean, Boolean, Boolean) -> Unit,
+    onClick: (FailedUpdatesManga) -> Unit,
+    onMigrateManga: (FailedUpdatesManga) -> Unit,
+) {
+    items(
+        items = items,
+        key = { it.libraryManga.manga.id },
+    ) { item ->
+        Box(modifier = Modifier.animateItemPlacement(animationSpec = tween(300))) {
+            DownloadStatUiItem(
+                modifier = Modifier,
+                selected = item.selected,
+                onLongClick = {
+                    onSelected(item, !item.selected, true, true)
+                },
+                onClick = {
+                    when {
+                        selectionMode -> onSelected(item, !item.selected, true, false)
+                        else -> onClick(item)
+                    }
+                },
+                manga = item,
+                onMigrateManga = { onMigrateManga(item) }.takeIf { !selectionMode },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadStatUiItem(
+    modifier: Modifier,
+    manga: FailedUpdatesManga,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onMigrateManga: (() -> Unit)?,
+) {
+    val haptic = LocalHapticFeedback.current
+    val textAlpha = 1f
+    Row(
+        modifier = modifier
+            .selectedBackground(selected)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = {
+                    onLongClick()
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                },
+            )
+            .height(56.dp)
+            .padding(horizontal = MaterialTheme.padding.medium),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MangaCover.Square(
+            modifier = Modifier
+                .padding(vertical = 6.dp)
+                .fillMaxHeight(),
+            data = manga.libraryManga.manga,
+        )
+
+        Column(
+            modifier = Modifier
+                .padding(start = MaterialTheme.padding.medium)
+                .weight(1f),
+        ) {
+            Text(
+                text = manga.libraryManga.manga.title,
+                maxLines = 1,
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalContentColor.current.copy(alpha = textAlpha),
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                var textHeight by remember { mutableIntStateOf(0) }
+                Text(
+                    text = manga.errorMessage ?: "Null",
+                    maxLines = 1,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    onTextLayout = { textHeight = it.size.height },
+                    modifier = Modifier
+                        .weight(weight = 1f, fill = false),
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        MigrateIndicator(
+            modifier = Modifier.padding(start = 4.dp),
+            onClick = { onMigrateManga?.invoke() },
+        )
+    }
+}
+
+fun returnSourceIcon(id: Long): ImageBitmap? {
+    return Injekt.get<ExtensionManager>().getAppIconForSource(id)
+        ?.toBitmap()
+        ?.asImageBitmap()
+}
+
+fun LazyListScope.downloadStatGroupUiItem(
+    items: List<FailedUpdatesManga>,
+    selectionMode: Boolean,
+    onSelected: (FailedUpdatesManga, Boolean, Boolean, Boolean) -> Unit,
+    onMangaClick: (FailedUpdatesManga) -> Unit,
+    id: String,
+    onMigrateManga: (FailedUpdatesManga) -> Unit,
+    onGroupSelected: (List<FailedUpdatesManga>) -> Unit,
+    expanded: MutableMap<String, Boolean>,
+    showLanguageInContent: Boolean = true,
+    isSourceOrCategory: Int,
+    sourcesCount: List<Pair<Source, Long>>,
+) {
+    var key = ""
+    items.forEachIndexed { index, item ->
+        key = "${item.category.id}_$index"
+    }
+    stickyHeader(key = if (isSourceOrCategory == 1) { items.find { it.source.name == id }!!.source.id } else { key }) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .animateItemPlacement()
+                .selectedBackground(!items.fastAny { !it.selected })
+                .combinedClickable(
+                    onClick = {
+                        expanded[id] = if (expanded[id] == null) {
+                            false
+                        } else {
+                            !expanded[id]!!
+                        }
+                    },
+                    onLongClick = { onGroupSelected(items) },
+                )
+                .padding(
+                    horizontal = MaterialTheme.padding.medium,
+                    vertical = MaterialTheme.padding.small,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isSourceOrCategory == 1) {
+                val item = items.find { it.source.name == id }!!.source
+                val sourceLangString = LocaleHelper.getSourceDisplayName(item.lang, LocalContext.current).takeIf { showLanguageInContent }
+                val icon = returnSourceIcon(item.id)
+                if (icon != null) {
+                    Image(
+                        bitmap = icon,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .height(50.dp)
+                            .aspectRatio(1f),
+                    )
+                }
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = MaterialTheme.padding.medium)
+                        .weight(1f),
+                ) {
+                    Text(
+                        text = item.name.ifBlank { item.id.toString() },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 16.sp,
+                        lineHeight = 24.sp,
+                        letterSpacing = 0.15.sp,
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (sourceLangString != null) {
+                            Text(
+                                modifier = Modifier.secondaryItemAlpha(),
+                                text = sourceLangString,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+                val mangaCount = items.size
+                val sourceCount = sourcesCount.find { it.first.id == item.id }!!.second
+                val pillAlpha = if (isSystemInDarkTheme()) 0.12f else 0.08f
+                Pill(
+                    text = "$mangaCount/$sourceCount",
+                    modifier = Modifier.padding(start = 4.dp),
+                    color = MaterialTheme.colorScheme.onBackground
+                        .copy(alpha = pillAlpha),
+                    fontSize = 14.sp,
+                )
+                val rotation by animateFloatAsState(
+                    targetValue = if (expanded[id] == true) 0f else -180f,
+                    animationSpec = tween(500),
+                )
+                Icon(
+                    imageVector = Icons.Filled.KeyboardArrowUp,
+                    modifier = Modifier
+                        .rotate(rotation)
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    contentDescription = null,
+                )
+            } else if (isSourceOrCategory == 2) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = MaterialTheme.padding.medium)
+                        .weight(1f),
+                ) {
+                    Text(
+                        id,
+                        style = typography.h6,
+                    )
+                }
+                val mangaCount = items.size
+                val pillAlpha = if (isSystemInDarkTheme()) 0.12f else 0.08f
+                Pill(
+                    text = "$mangaCount",
+                    modifier = Modifier.padding(start = 4.dp),
+                    color = MaterialTheme.colorScheme.onBackground
+                        .copy(alpha = pillAlpha),
+                    fontSize = 14.sp,
+                )
+                val rotation by animateFloatAsState(
+                    targetValue = if (expanded[id] == true) 0f else -180f,
+                    animationSpec = tween(500),
+                )
+                Icon(
+                    imageVector = Icons.Filled.KeyboardArrowUp,
+                    modifier = Modifier
+                        .rotate(rotation)
+                        .padding(vertical = 8.dp, horizontal = 25.dp),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+
+    itemsIndexed(items, key = { _, item -> item.libraryManga.manga.id }) { _, item ->
+        AnimatedVisibility(
+            modifier = Modifier.animateItemPlacement(),
+            visible = expanded[id] == true,
+        ) {
+            DownloadStatUiItem(
+                modifier = Modifier,
+                selected = item.selected,
+                onLongClick = {
+                    onSelected(item, !item.selected, true, true)
+                },
+                onClick = {
+                    when {
+                        selectionMode -> onSelected(item, !item.selected, true, false)
+                        else -> onMangaClick(item)
+                    }
+                },
+                manga = item,
+                onMigrateManga = { onMigrateManga(item) }.takeIf { !selectionMode },
+            )
+        }
+    }
+}
+
+@Composable
+fun MigrateIndicator(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = Icons.Outlined.FlightTakeoff,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.height(3.3.dp))
+            Text(
+                text = stringResource(R.string.action_migrate),
+                fontSize = 12.sp,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+fun CategoryList(
+    contentPadding: PaddingValues,
+    selectionMode: Boolean,
+    onMangaClick: (FailedUpdatesManga) -> Unit,
+    onMigrateManga: (FailedUpdatesManga) -> Unit,
+    onGroupSelected: (List<FailedUpdatesManga>) -> Unit,
+    onSelected: (FailedUpdatesManga, Boolean, Boolean, Boolean) -> Unit,
+    categoryMap: Map<String, List<FailedUpdatesManga>>,
+    isSourceOrCategory: Int,
+    expanded: MutableMap<String, Boolean>,
+    sourcesCount: List<Pair<Source, Long>>,
+) {
+    FastScrollLazyColumn(contentPadding = contentPadding, modifier = Modifier.fillMaxHeight()) {
+        categoryMap.forEach { (category, items) ->
+            downloadStatGroupUiItem(
+                id = category,
+                items = items,
+                selectionMode = selectionMode,
+                onMangaClick = onMangaClick,
+                onSelected = onSelected,
+                onMigrateManga = onMigrateManga,
+                onGroupSelected = onGroupSelected,
+                expanded = expanded,
+                isSourceOrCategory = isSourceOrCategory,
+                sourcesCount = sourcesCount,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesScreen.kt
@@ -1,0 +1,432 @@
+package eu.kanade.presentation.updates.failed
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowLeft
+import androidx.compose.material.icons.outlined.ArrowRight
+import androidx.compose.material.icons.outlined.FlipToBack
+import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material.icons.outlined.Sort
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.presentation.components.DropdownMenu
+import eu.kanade.presentation.components.NestedMenuItem
+import eu.kanade.presentation.library.DeleteLibraryMangaDialog
+import eu.kanade.presentation.manga.components.FailedUpdatesBottomActionMenu
+import eu.kanade.presentation.updates.setWarningIconEnabled
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
+import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.presentation.core.components.FastScrollLazyColumn
+import tachiyomi.presentation.core.components.Pill
+import tachiyomi.presentation.core.components.SortItem
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.source.local.isLocal
+
+class FailedUpdatesScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        val screenModel = rememberScreenModel { FailedUpdatesScreenModel() }
+        val state by screenModel.state.collectAsState()
+
+        val categoryExpandedMapSaver: Saver<MutableMap<String, Boolean>, *> = Saver(
+            save = { map -> map.toMap() },
+            restore = { map -> mutableStateMapOf(*map.toList().toTypedArray()) },
+        )
+        var expanded = emptyMap<String, Boolean>().toMutableMap()
+
+        if (screenModel.failedUpdates.isEmpty()) {
+            setWarningIconEnabled(false)
+        }
+
+        Scaffold(
+            topBar = { scrollBehavior ->
+                DownloadStatsAppBar(
+                    groupByMode = state.groupByMode,
+                    items = state.items,
+                    selected = state.selected,
+                    onSelectAll = { screenModel.toggleAllSelection(true) },
+                    onIgnoreAll = { screenModel.dismissManga(state.items) },
+                    onExpandAll = { expanded.keys.forEach { expanded[it] = true } },
+                    onContractAll = { expanded.keys.forEach { expanded[it] = false } },
+                    onInvertSelection = { screenModel.invertSelection() },
+                    onCancelActionMode = { screenModel.toggleAllSelection(false) },
+                    scrollBehavior = scrollBehavior,
+                    onClickGroup = screenModel::runGroupBy,
+                    onClickSort = screenModel::runSortAction,
+                    sortState = state.sortMode,
+                    descendingOrder = state.descendingOrder,
+                    navigateUp = navigator::pop,
+                    errorCount = state.items.size,
+                )
+            },
+            bottomBar = {
+                FailedUpdatesBottomActionMenu(
+                    visible = state.selectionMode,
+                    onDeleteClicked = { screenModel.openDeleteMangaDialog(state.selected) },
+                    onDismissClicked = { screenModel.dismissManga(state.selected) },
+                )
+            },
+        ) { contentPadding ->
+            when {
+                state.isLoading -> LoadingScreen(modifier = Modifier.padding(contentPadding))
+
+                state.items.isEmpty() -> EmptyScreen(
+                    textResource = R.string.information_no_errors,
+                    modifier = Modifier.padding(contentPadding),
+                    selector = 2,
+                )
+
+                else -> {
+                    when (state.groupByMode) {
+                        GroupByMode.NONE -> FastScrollLazyColumn(
+                            contentPadding = contentPadding,
+                        ) {
+                            downloadStatUiItems(
+                                items = state.items,
+                                selectionMode = state.selectionMode,
+                                onClick = { item ->
+                                    navigator.push(
+                                        MangaScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                                onSelected = screenModel::toggleSelection,
+                                onMigrateManga = { item ->
+                                    navigator.push(
+                                        MigrateSearchScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                            )
+                        }
+
+                        GroupByMode.BY_SOURCE -> {
+                            val categoryMap = screenModel.categoryMap(
+                                state.items,
+                                GroupByMode.BY_SOURCE,
+                                state.sortMode,
+                                state.descendingOrder,
+                            )
+                            expanded = rememberSaveable(
+                                saver = categoryExpandedMapSaver,
+                                key = "CategoryExpandedMap",
+                                init = { mutableStateMapOf(*categoryMap.keys.toList().map { it to false }.toTypedArray()) },
+                            )
+                            CategoryList(
+                                contentPadding = contentPadding,
+                                selectionMode = state.selectionMode,
+                                onMangaClick = { item ->
+                                    navigator.push(
+                                        MangaScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                                onMigrateManga = { item ->
+                                    navigator.push(
+                                        MigrateSearchScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                                onGroupSelected = screenModel::groupSelection,
+                                onSelected = screenModel::toggleSelection,
+                                categoryMap = categoryMap,
+                                isSourceOrCategory = 1,
+                                expanded = expanded,
+                                sourcesCount = state.sourcesCount,
+                            )
+                        }
+
+                        GroupByMode.BY_CATEGORY -> {
+                            val categoryMap = screenModel.categoryMap(
+                                state.items,
+                                GroupByMode.BY_CATEGORY,
+                                state.sortMode,
+                                state.descendingOrder,
+                            )
+                            expanded = rememberSaveable(
+                                saver = categoryExpandedMapSaver,
+                                key = "CategoryExpandedMap",
+                                init = { mutableStateMapOf(*categoryMap.keys.toList().map { it to false }.toTypedArray()) },
+                            )
+                            CategoryList(
+                                contentPadding = contentPadding,
+                                selectionMode = state.selectionMode,
+                                onMangaClick = { item ->
+                                    navigator.push(
+                                        MangaScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                                onMigrateManga = { item ->
+                                    navigator.push(
+                                        MigrateSearchScreen(item.libraryManga.manga.id),
+                                    )
+                                },
+                                onGroupSelected = screenModel::groupSelection,
+                                onSelected = screenModel::toggleSelection,
+                                categoryMap = categoryMap,
+                                isSourceOrCategory = 2,
+                                expanded = expanded,
+                                sourcesCount = state.sourcesCount,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        val onDismissRequest = screenModel::closeDialog
+        when (val dialog = state.dialog) {
+            is Dialog.DeleteManga -> {
+                DeleteLibraryMangaDialog(
+                    containsLocalManga = dialog.manga.any(Manga::isLocal),
+                    onDismissRequest = onDismissRequest,
+                    onConfirm = { deleteManga, deleteChapter ->
+                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter)
+                        screenModel.toggleAllSelection(false)
+                    },
+                )
+            }
+            null -> {}
+        }
+    }
+}
+
+@Composable
+private fun DownloadStatsAppBar(
+    groupByMode: GroupByMode,
+    items: List<FailedUpdatesManga>,
+    modifier: Modifier = Modifier,
+    selected: List<FailedUpdatesManga>,
+    onSelectAll: () -> Unit,
+    onInvertSelection: () -> Unit,
+    onCancelActionMode: () -> Unit,
+    onClickSort: (SortingMode) -> Unit,
+    onClickGroup: (GroupByMode) -> Unit,
+    onIgnoreAll: () -> Unit,
+    onExpandAll: () -> Unit,
+    onContractAll: () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior,
+    sortState: SortingMode,
+    descendingOrder: Boolean? = null,
+    navigateUp: (() -> Unit)?,
+    errorCount: Int,
+) {
+    if (selected.isNotEmpty()) {
+        DownloadStatsActionAppBar(
+            modifier = modifier,
+            onSelectAll = onSelectAll,
+            onInvertSelection = onInvertSelection,
+            onCancelActionMode = onCancelActionMode,
+            scrollBehavior = scrollBehavior,
+            navigateUp = navigateUp,
+            actionModeCounter = selected.size,
+        )
+        BackHandler(
+            onBack = onCancelActionMode,
+        )
+    } else {
+        AppBar(
+            navigateUp = navigateUp,
+            titleContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(R.string.label_failed_updates),
+                        maxLines = 1,
+                        modifier = Modifier.weight(1f, false),
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (errorCount > 0) {
+                        val pillAlpha = if (isSystemInDarkTheme()) 0.12f else 0.08f
+                        Pill(
+                            text = "$errorCount",
+                            modifier = Modifier.padding(start = 4.dp),
+                            color = MaterialTheme.colorScheme.onBackground
+                                .copy(alpha = pillAlpha),
+                            fontSize = 14.sp,
+                        )
+                    }
+                }
+            },
+            actions = {
+                if (items.isNotEmpty()) {
+                    val filterTint = LocalContentColor.current
+                    var sortExpanded by remember { mutableStateOf(false) }
+                    val onSortDismissRequest = { sortExpanded = false }
+                    var mainExpanded by remember { mutableStateOf(false) }
+                    var expandAll by remember { mutableStateOf(false) }
+                    val onDismissRequest = { mainExpanded = false }
+                    SortDropdownMenu(
+                        expanded = sortExpanded,
+                        onDismissRequest = onSortDismissRequest,
+                        onSortClicked = onClickSort,
+                        sortState = sortState,
+                        descendingOrder = descendingOrder,
+                    )
+                    DropdownMenu(expanded = mainExpanded, onDismissRequest = onDismissRequest) {
+                        NestedMenuItem(
+                            text = { Text(text = stringResource(R.string.action_groupBy)) },
+                            children = { closeMenu ->
+                                DropdownMenuItem(
+                                    text = { Text(text = stringResource(R.string.action_group_by_source)) },
+                                    onClick = {
+                                        onClickGroup(GroupByMode.BY_SOURCE)
+                                        closeMenu()
+                                        onDismissRequest()
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(text = stringResource(R.string.action_group_by_category)) },
+                                    onClick = {
+                                        onClickGroup(GroupByMode.BY_CATEGORY)
+                                        closeMenu()
+                                        onDismissRequest()
+                                    },
+                                )
+                            },
+                        )
+                        val isLtr = LocalLayoutDirection.current == LayoutDirection.Ltr
+                        DropdownMenuItem(
+                            text = { Text(text = stringResource(R.string.action_sortBy)) },
+                            onClick = {
+                                onDismissRequest()
+                                sortExpanded = !sortExpanded
+                            },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = if (isLtr) Icons.Outlined.ArrowRight else Icons.Outlined.ArrowLeft,
+                                    contentDescription = null,
+                                )
+                            },
+                        )
+                    }
+                    val actions = mutableListOf<AppBar.AppBarAction>()
+                    actions += AppBar.Action(
+                        title = stringResource(R.string.action_sort),
+                        icon = Icons.Outlined.Sort,
+                        iconTint = filterTint,
+                        onClick = { mainExpanded = !mainExpanded },
+                    )
+                    actions += AppBar.OverflowAction(
+                        title = stringResource(R.string.action_ignore_all),
+                        onClick = onIgnoreAll,
+                    )
+                    if (groupByMode != GroupByMode.NONE) {
+                        if (expandAll) {
+                            actions += AppBar.OverflowAction(
+                                title = stringResource(R.string.action_contract_all),
+                                onClick = {
+                                    onContractAll()
+                                    expandAll = false
+                                },
+                            )
+                        } else {
+                            actions += AppBar.OverflowAction(
+                                title = stringResource(R.string.action_expand_all),
+                                onClick = {
+                                    onExpandAll()
+                                    expandAll = true
+                                },
+                            )
+                        }
+                    }
+                    if (groupByMode != GroupByMode.NONE) {
+                        actions += AppBar.OverflowAction(
+                            title = stringResource(R.string.action_ungroup),
+                            onClick = { onClickGroup(GroupByMode.NONE) },
+                        )
+                    }
+                    AppBarActions(actions)
+                }
+            },
+            scrollBehavior = scrollBehavior,
+        )
+    }
+}
+
+@Composable
+private fun DownloadStatsActionAppBar(
+    modifier: Modifier = Modifier,
+    actionModeCounter: Int,
+    onSelectAll: () -> Unit,
+    onInvertSelection: () -> Unit,
+    onCancelActionMode: () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior,
+    navigateUp: (() -> Unit)?,
+) {
+    AppBar(
+        modifier = modifier,
+        title = stringResource(R.string.label_failed_updates),
+        actionModeCounter = actionModeCounter,
+        onCancelActionMode = onCancelActionMode,
+        actionModeActions = {
+            AppBarActions(
+                listOf(
+                    AppBar.Action(
+                        title = stringResource(R.string.action_select_all),
+                        icon = Icons.Outlined.SelectAll,
+                        onClick = onSelectAll,
+                    ),
+                    AppBar.Action(
+                        title = stringResource(R.string.action_select_inverse),
+                        icon = Icons.Outlined.FlipToBack,
+                        onClick = onInvertSelection,
+                    ),
+                ),
+            )
+        },
+        scrollBehavior = scrollBehavior,
+        navigateUp = navigateUp,
+    )
+}
+
+@Composable
+fun SortDropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    onSortClicked: (SortingMode) -> Unit,
+    sortState: SortingMode,
+    descendingOrder: Boolean? = null,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+    ) {
+        SortItem(
+            label = stringResource(R.string.action_sort_A_Z),
+            sortDescending = descendingOrder.takeIf { sortState == SortingMode.BY_ALPHABET },
+            onClick = { onSortClicked(SortingMode.BY_ALPHABET) },
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/failed/FailedUpdatesScreenModel.kt
@@ -1,0 +1,365 @@
+package eu.kanade.presentation.updates.failed
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.res.stringResource
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.coroutineScope
+import eu.kanade.core.util.addOrRemove
+import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.GetSourcesWithFavoriteCount
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.removeCovers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import logcat.LogPriority
+import tachiyomi.core.preference.PreferenceStore
+import tachiyomi.core.preference.getEnum
+import tachiyomi.core.util.lang.launchIO
+import tachiyomi.core.util.lang.launchNonCancellable
+import tachiyomi.core.util.system.logcat
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.library.model.LibraryManga
+import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaUpdate
+import tachiyomi.domain.source.model.Source
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.TreeMap
+
+class FailedUpdatesScreenModel(
+    private val getLibraryManga: GetLibraryManga = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadManager: DownloadManager = Injekt.get(),
+    private val updateManga: UpdateManga = Injekt.get(),
+    private val coverCache: CoverCache = Injekt.get(),
+    private val getCategories: GetCategories = Injekt.get(),
+    private val getSourcesWithFavoriteCount: GetSourcesWithFavoriteCount = Injekt.get(),
+    private val preferenceStore: PreferenceStore = Injekt.get(),
+) : StateScreenModel<FailedUpdatesScreenState>(FailedUpdatesScreenState()) {
+
+    var failedUpdates = LibraryUpdateJob.getNewFailedUpdates()
+    private val selectedPositions: Array<Int> = arrayOf(-1, -1)
+    private val selectedMangaIds: HashSet<Long> = HashSet()
+    private val _channel = Channel<Event>(Int.MAX_VALUE)
+    val channel = _channel.receiveAsFlow()
+
+    init {
+        coroutineScope.launchIO {
+            val sortMode = preferenceStore.getEnum("sort_mode", SortingMode.BY_ALPHABET).get()
+            getSourcesWithFavoriteCount.subscribe()
+                .catch {
+                    logcat(LogPriority.ERROR, it)
+                    _channel.send(Event.FailedFetchingSourcesWithCount)
+                }
+                .collectLatest { sources ->
+                    mutableState.update { state ->
+                        val categories = getCategories.await().associateBy { group -> group.id }
+                        state.copy(
+                            sourcesCount = sources,
+                            items = getLibraryManga.await().filter { libraryManga ->
+                                failedUpdates.any { it.first.id == libraryManga.manga.id }
+                            }.map { libraryManga ->
+                                val source = sourceManager.get(libraryManga.manga.source)!!
+                                val errorMessage = failedUpdates.find {
+                                    it.first.id == libraryManga.manga.id
+                                }?.second
+                                FailedUpdatesManga(
+                                    libraryManga = libraryManga,
+                                    errorMessage = errorMessage,
+                                    selected = libraryManga.id in selectedMangaIds,
+                                    source = source,
+                                    category = categories[libraryManga.category]!!,
+                                )
+                            },
+                            groupByMode = preferenceStore.getEnum("group_by_mode", GroupByMode.NONE).get(),
+                            sortMode = sortMode,
+                            descendingOrder = preferenceStore.getBoolean("descending_order", false).get(),
+                            isLoading = false,
+                        )
+                    }
+                }
+            runSortAction(sortMode)
+        }
+    }
+
+    fun runSortAction(mode: SortingMode) {
+        when (mode) {
+            SortingMode.BY_ALPHABET -> sortByAlphabet()
+        }
+    }
+
+    fun runGroupBy(mode: GroupByMode) {
+        when (mode) {
+            GroupByMode.NONE -> unGroup()
+            GroupByMode.BY_CATEGORY -> groupByCategory()
+            GroupByMode.BY_SOURCE -> groupBySource()
+        }
+    }
+
+    private fun sortByAlphabet() {
+        mutableState.update { state ->
+            val descendingOrder = if (state.sortMode == SortingMode.BY_ALPHABET) !state.descendingOrder else false
+            preferenceStore.getBoolean("descending_order", false).set(descendingOrder)
+            state.copy(
+                items = if (descendingOrder) state.items.sortedByDescending { it.libraryManga.manga.title } else state.items.sortedBy { it.libraryManga.manga.title },
+                descendingOrder = descendingOrder,
+                sortMode = SortingMode.BY_ALPHABET,
+            )
+        }
+        preferenceStore.getEnum("sort_mode", SortingMode.BY_ALPHABET).set(SortingMode.BY_ALPHABET)
+    }
+
+    @Composable
+    fun categoryMap(items: List<FailedUpdatesManga>, groupMode: GroupByMode, sortMode: SortingMode, descendingOrder: Boolean): Map<String, List<FailedUpdatesManga>> {
+        val unsortedMap = when (groupMode) {
+            GroupByMode.BY_CATEGORY -> items.groupBy { if (it.category.isSystemCategory) { stringResource(R.string.label_default) } else { it.category.name } }
+            GroupByMode.BY_SOURCE -> items.groupBy { it.source.name }
+            GroupByMode.NONE -> emptyMap()
+        }
+        return when (sortMode) {
+            SortingMode.BY_ALPHABET -> {
+                val sortedMap = TreeMap<String, List<FailedUpdatesManga>>(if (descendingOrder) { compareByDescending { it } } else { compareBy { it } })
+                sortedMap.putAll(unsortedMap)
+                sortedMap
+            }
+        }
+    }
+
+    private fun groupBySource() {
+        mutableState.update {
+            it.copy(
+                groupByMode = GroupByMode.BY_SOURCE,
+            )
+        }
+        preferenceStore.getEnum("group_by_mode", GroupByMode.NONE).set(GroupByMode.BY_SOURCE)
+    }
+
+    private fun groupByCategory() {
+        mutableState.update {
+            it.copy(
+                groupByMode = GroupByMode.BY_CATEGORY,
+            )
+        }
+        preferenceStore.getEnum("group_by_mode", GroupByMode.NONE).set(GroupByMode.BY_CATEGORY)
+    }
+
+    private fun unGroup() {
+        mutableState.update {
+            it.copy(
+                groupByMode = GroupByMode.NONE,
+            )
+        }
+        preferenceStore.getEnum("group_by_mode", GroupByMode.NONE).set(GroupByMode.NONE)
+    }
+
+    fun toggleSelection(
+        item: FailedUpdatesManga,
+        selected: Boolean,
+        userSelected: Boolean = false,
+        fromLongPress: Boolean = false,
+    ) {
+        mutableState.update { state ->
+            val newItems = state.items.toMutableList().apply {
+                val selectedIndex = indexOfFirst { it.libraryManga.manga.id == item.libraryManga.manga.id }
+                if (selectedIndex < 0) return@apply
+
+                val selectedItem = get(selectedIndex)
+                if (selectedItem.selected == selected) return@apply
+
+                val firstSelection = none { it.selected }
+                set(selectedIndex, selectedItem.copy(selected = selected))
+                selectedMangaIds.addOrRemove(item.libraryManga.manga.id, selected)
+
+                if (selected && userSelected && fromLongPress) {
+                    if (firstSelection) {
+                        selectedPositions[0] = selectedIndex
+                        selectedPositions[1] = selectedIndex
+                    } else {
+                        // Try to select the items in-between when possible
+                        val range: IntRange
+                        if (selectedIndex < selectedPositions[0]) {
+                            range = selectedIndex + 1 until selectedPositions[0]
+                            selectedPositions[0] = selectedIndex
+                        } else if (selectedIndex > selectedPositions[1]) {
+                            range = (selectedPositions[1] + 1) until selectedIndex
+                            selectedPositions[1] = selectedIndex
+                        } else {
+                            // Just select itself
+                            range = IntRange.EMPTY
+                        }
+
+                        range.forEach {
+                            val inBetweenItem = get(it)
+                            if (!inBetweenItem.selected) {
+                                selectedMangaIds.add(inBetweenItem.libraryManga.manga.id)
+                                set(it, inBetweenItem.copy(selected = true))
+                            }
+                        }
+                    }
+                } else if (userSelected && !fromLongPress) {
+                    if (!selected) {
+                        if (selectedIndex == selectedPositions[0]) {
+                            selectedPositions[0] = indexOfFirst { it.selected }
+                        } else if (selectedIndex == selectedPositions[1]) {
+                            selectedPositions[1] = indexOfLast { it.selected }
+                        }
+                    } else {
+                        if (selectedIndex < selectedPositions[0]) {
+                            selectedPositions[0] = selectedIndex
+                        } else if (selectedIndex > selectedPositions[1]) {
+                            selectedPositions[1] = selectedIndex
+                        }
+                    }
+                }
+            }
+            state.copy(items = newItems)
+        }
+    }
+
+    fun toggleAllSelection(selected: Boolean) {
+        mutableState.update { state ->
+            val newItems = state.items.map {
+                selectedMangaIds.addOrRemove(it.libraryManga.manga.id, selected)
+                it.copy(selected = selected)
+            }
+            state.copy(items = newItems)
+        }
+
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+    }
+
+    fun removeMangas(mangaList: List<Manga>, deleteFromLibrary: Boolean, deleteChapters: Boolean) {
+        coroutineScope.launchNonCancellable {
+            val mangaToDelete = mangaList.distinctBy { it.id }
+
+            if (deleteFromLibrary) {
+                val toDelete = mangaToDelete.map {
+                    it.removeCovers(coverCache)
+                    MangaUpdate(
+                        favorite = false,
+                        id = it.id,
+                    )
+                }
+                updateManga.awaitAll(toDelete)
+            }
+
+            if (deleteChapters) {
+                mangaToDelete.forEach { manga ->
+                    val source = sourceManager.get(manga.source) as? HttpSource
+                    if (source != null) {
+                        downloadManager.deleteManga(manga, source)
+                    }
+                }
+            }
+        }
+        if (deleteFromLibrary) {
+            val set = mangaList.map { it.id }.toHashSet()
+            mutableState.update { state ->
+                state.copy(
+                    items = state.items.filterNot { it.libraryManga.id in set },
+                )
+            }
+            failedUpdates = failedUpdates.filterNot { it.first.id in set }
+            LibraryUpdateJob.setNewFailedUpdates(set)
+        }
+    }
+
+    fun dismissManga(selected: List<FailedUpdatesManga>) {
+        val set = selected.map { it.libraryManga.id }.toHashSet()
+        toggleAllSelection(false)
+        mutableState.update { state ->
+            state.copy(
+                items = state.items.filterNot { it.libraryManga.id in set },
+            )
+        }
+        failedUpdates = failedUpdates.filterNot { it.first.id in set }
+        LibraryUpdateJob.setNewFailedUpdates(set)
+    }
+
+    fun openDeleteMangaDialog(selected: List<FailedUpdatesManga>) {
+        val mangaList = selected.map { it.libraryManga.manga }
+        mutableState.update { it.copy(dialog = Dialog.DeleteManga(mangaList)) }
+    }
+
+    fun closeDialog() {
+        mutableState.update { it.copy(dialog = null) }
+    }
+
+    fun invertSelection() {
+        mutableState.update { state ->
+            val newItems = state.items.map {
+                selectedMangaIds.addOrRemove(it.libraryManga.manga.id, !it.selected)
+                it.copy(selected = !it.selected)
+            }
+            state.copy(items = newItems)
+        }
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+    }
+
+    fun groupSelection(items: List<FailedUpdatesManga>) {
+        val newSelected = items.map { manga -> manga.libraryManga.id }.toHashSet()
+        selectedMangaIds.addAll(newSelected)
+        mutableState.update { state ->
+            val newItems = state.items.map {
+                it.copy(selected = if (it.libraryManga.id in newSelected) !it.selected else it.selected)
+            }
+            state.copy(items = newItems)
+        }
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+    }
+}
+
+enum class GroupByMode {
+    NONE,
+    BY_CATEGORY,
+    BY_SOURCE,
+}
+
+enum class SortingMode {
+    BY_ALPHABET,
+}
+
+sealed class Dialog {
+    data class DeleteManga(val manga: List<Manga>) : Dialog()
+}
+
+sealed class Event {
+    data object FailedFetchingSourcesWithCount : Event()
+}
+
+@Immutable
+data class FailedUpdatesManga(
+    val libraryManga: LibraryManga,
+    val errorMessage: String?,
+    val selected: Boolean = false,
+    val source: eu.kanade.tachiyomi.source.Source,
+    val category: Category,
+)
+
+@Immutable
+data class FailedUpdatesScreenState(
+    val isLoading: Boolean = true,
+    val items: List<FailedUpdatesManga> = emptyList(),
+    val groupByMode: GroupByMode = GroupByMode.NONE,
+    val sortMode: SortingMode = SortingMode.BY_ALPHABET,
+    val descendingOrder: Boolean = false,
+    val dialog: Dialog? = null,
+    val sourcesCount: List<Pair<Source, Long>> = emptyList(),
+) {
+    val selected = items.filter { it.selected }
+    val selectionMode = selected.isNotEmpty()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -21,6 +21,7 @@ import eu.kanade.domain.manga.model.copyFrom
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.track.model.toDbTrack
 import eu.kanade.domain.track.model.toDomainTrack
+import eu.kanade.presentation.updates.setWarningIconEnabled
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
@@ -319,6 +320,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
 
         if (failedUpdates.isNotEmpty()) {
+            newFailedUpdates = failedUpdates
+            setWarningIconEnabled(true)
             val errorFile = writeErrorFile(failedUpdates)
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
@@ -549,6 +552,16 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
          * Key that defines what should be updated.
          */
         private const val KEY_TARGET = "target"
+
+        private var newFailedUpdates: List<Pair<Manga, String?>> = emptyList()
+
+        fun getNewFailedUpdates(): List<Pair<Manga, String?>> {
+            return newFailedUpdates
+        }
+
+        fun setNewFailedUpdates(set: HashSet<Long>) {
+            newFailedUpdates = newFailedUpdates.filterNot { it.first.id in set }
+        }
 
         fun cancelAllWorks(context: Context) {
             context.workManager.cancelAllWorkByTag(TAG)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -18,6 +18,7 @@ import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import eu.kanade.presentation.updates.UpdateScreen
 import eu.kanade.presentation.updates.UpdatesDeleteConfirmationDialog
+import eu.kanade.presentation.updates.failed.FailedUpdatesScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
@@ -61,6 +62,7 @@ object UpdatesTab : Tab {
             onSelectAll = screenModel::toggleAllSelection,
             onInvertSelection = screenModel::invertSelection,
             onUpdateLibrary = screenModel::updateLibrary,
+            onUpdateWarning = { navigator.push(FailedUpdatesScreen()) },
             onDownloadChapter = screenModel::downloadChapters,
             onMultiBookmarkClicked = screenModel::bookmarkUpdates,
             onMultiMarkAsReadClicked = screenModel::markUpdatesRead,

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="label_download_queue">Download queue</string>
     <string name="label_library">Library</string>
     <string name="label_recent_updates">Updates</string>
+    <string name="label_failed_updates">Failed updates</string>
     <string name="label_recent_manga">History</string>
     <string name="label_sources">Sources</string>
     <string name="label_backup">Backup and restore</string>
@@ -57,6 +58,7 @@
     <!-- reserved for #4048 -->
     <string name="action_filter_empty">Remove filter</string>
     <string name="action_sort_alpha">Alphabetically</string>
+    <string name="action_sort_A_Z">A-Z</string>
     <string name="action_sort_count">Total entries</string>
     <string name="action_sort_total">Total chapters</string>
     <string name="action_sort_last_read">Last read</string>
@@ -105,6 +107,12 @@
     <string name="action_open_in_browser">Open in browser</string>
     <string name="action_show_manga">Show entry</string>
     <string name="action_copy_to_clipboard">Copy to clipboard</string>
+    <string name="action_group_by_category">Category</string>
+    <string name="action_group_by_source">Source</string>
+    <string name="action_ungroup">Ungroup</string>
+    <string name="action_ignore_all">Ignore all</string>
+    <string name="action_expand_all">Expand all</string>
+    <string name="action_contract_all">Contract all</string>
     <!-- Do not translate "WebView" -->
     <string name="action_open_in_web_view">Open in WebView</string>
     <string name="action_web_view" translatable="false">WebView</string>
@@ -128,6 +136,8 @@
     <string name="action_ok">OK</string>
     <string name="action_cancel_all">Cancel all</string>
     <string name="cancel_all_for_series">Cancel all for this series</string>
+    <string name="action_sortBy">Sort by</string>
+    <string name="action_groupBy">Group by</string>
     <string name="action_sort">Sort</string>
     <string name="action_order_by_upload_date">By upload date</string>
     <string name="action_order_by_chapter_number">By chapter number</string>
@@ -898,6 +908,7 @@
 
     <!-- Information Text -->
     <string name="information_no_downloads">No downloads</string>
+    <string name="information_no_errors">No errors found</string>
     <string name="information_no_recent">No recent updates</string>
     <string name="information_no_recent_manga">Nothing read recently</string>
     <string name="information_empty_library">Your library is empty</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -36,8 +36,10 @@ fun EmptyScreen(
     @StringRes textResource: Int,
     modifier: Modifier = Modifier,
     actions: List<EmptyScreenAction>? = null,
+    selector: Int = 1,
 ) {
     EmptyScreen(
+        selector = selector,
         message = stringResource(textResource),
         modifier = modifier,
         actions = actions,
@@ -49,8 +51,9 @@ fun EmptyScreen(
     message: String,
     modifier: Modifier = Modifier,
     actions: List<EmptyScreenAction>? = null,
+    selector: Int = 1,
 ) {
-    val face = remember { getRandomErrorFace() }
+    val face = remember { getRandomFace(selector) }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -101,7 +104,18 @@ private val ERROR_FACES = listOf(
     "(；￣Д￣)",
     "(･Д･。",
 )
-
-private fun getRandomErrorFace(): String {
-    return ERROR_FACES[Random.nextInt(ERROR_FACES.size)]
+private val HAPPY_FACES = listOf(
+    "ヽ(＾Д＾)ﾉ",
+    "≧◡≦",
+    "＾ω＾",
+    "＾▽＾",
+    "(◕‿◕)",
+    "◠‿◠",
+)
+private fun getRandomFace(selector: Int): String {
+    if (selector == 1) {
+        return ERROR_FACES[Random.nextInt(ERROR_FACES.size)]
+    } else {
+        return HAPPY_FACES[Random.nextInt(HAPPY_FACES.size)]
+    }
 }


### PR DESCRIPTION
This should finally (and hopefully) close #4616. Here are some images about the newly added feature:

<details>
<summary>Details</summary>

| The warning icon is disabled and not visible by default but when an update job is run, and an error is detected it will become enabled| For now I only did it as a list (no grid view) and the migrate button has the same function as going to the migrate source screen|
| -------------   | ------------- |
![WhatsApp Image 2023-08-02 at 22 24 46](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/9c1d214e-a4a4-40fa-b438-405eb2ec7c9d)|                    ![WhatsApp Image 2023-08-02 at 22 24 46](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/df7b604c-26d0-47db-a455-d08194c2ed7a)
| I took @T3sT3ro advice and made the Pills to display the error count along side with the total count of mangas in that source| In the bottom bar there is a delete button as well as a dismiss button|
![WhatsApp Image 2023-08-02 at 22 24 48](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/d6ecd086-e9ad-4433-9abd-1c6c98f65e76) |        ![WhatsApp Image 2023-08-02 at 22 24 50](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/61f03a35-c6eb-4630-b0f9-00d1e7dc2a10)    
| There is also an option to group by category but I couldn't find a way to efficiently get the total manga count in that category   |I edited the EmptyScreen function to display happy faces when you dismiss or ignore all the errors|
![WhatsApp Image 2023-08-02 at 22 34 39](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/9f8588a4-037b-4fba-aebe-c2aaedb0d881) | ![WhatsApp Image 2023-08-02 at 22 34 39](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/08a44eff-67a7-4634-b7c1-50c718448b8d)

</details>

<details>
<summary>Extra Image</summary>

![WhatsApp Image 2023-08-02 at 22 24 48](https://github.com/tachiyomiorg/tachiyomi/assets/67505416/ce63c82f-698c-435d-b3c8-7a544f5b26d1)

</details>

As I'm still a university student, I don't have much experience with Koltin, so I'd like to give most of the credit of this PR to @semenvav as I took his code from #9737 as reference to create this feature. 

If you notice any mistakes in the code or if you have a more efficient way of writing it, then please notify me so I can fix it.