### PR TITLE
Add local chapter

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -48,6 +48,7 @@ class SetReadStatus(
 
         if (read && downloadPreferences.removeAfterMarkedAsRead().get()) {
             chaptersToUpdate
+                .filterNot { it.localChapter }
                 .groupBy { it.mangaId }
                 .forEach { (mangaId, chapters) ->
                     deleteDownload.awaitAll(

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -80,7 +80,7 @@ class SyncChaptersWithSource(
         val toDelete = dbChapters.filterNot { dbChapter ->
             sourceChapters.any { sourceChapter ->
                 dbChapter.url == sourceChapter.url
-            }
+            } || dbChapter.localChapter
         }
 
         val rightNow = Date().time

--- a/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
@@ -50,4 +50,5 @@ fun Chapter.toDbChapter(): DbChapter = ChapterImpl().also {
     it.date_upload = dateUpload
     it.chapter_number = chapterNumber.toFloat()
     it.source_order = sourceOrder.toInt()
+    it.localChapter = localChapter
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -52,6 +52,7 @@ import eu.kanade.domain.manga.model.chaptersFiltered
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.ChapterHeader
 import eu.kanade.presentation.manga.components.ExpandableMangaDescription
+import eu.kanade.presentation.manga.components.LocalChapterAction
 import eu.kanade.presentation.manga.components.MangaActionRow
 import eu.kanade.presentation.manga.components.MangaBottomActionMenu
 import eu.kanade.presentation.manga.components.MangaChapterListItem
@@ -96,6 +97,7 @@ fun MangaScreen(
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
     onTrackingClicked: (() -> Unit)?,
+    onLocalChapter: ((List<ChapterItem>, LocalChapterAction) -> Unit)?,
 
     // For tags menu
     onTagSearch: (String) -> Unit,
@@ -171,6 +173,7 @@ fun MangaScreen(
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
             onInvertSelection = onInvertSelection,
+            onLocalChapter = onLocalChapter,
         )
     } else {
         MangaScreenLargeImpl(
@@ -207,6 +210,7 @@ fun MangaScreen(
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
             onInvertSelection = onInvertSelection,
+            onLocalChapter = onLocalChapter,
         )
     }
 }
@@ -226,6 +230,7 @@ private fun MangaScreenSmallImpl(
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
     onTrackingClicked: (() -> Unit)?,
+    onLocalChapter: ((List<ChapterItem>, LocalChapterAction) -> Unit)?,
 
     // For tags menu
     onTagSearch: (String) -> Unit,
@@ -435,6 +440,7 @@ private fun MangaScreenSmallImpl(
                         onDownloadChapter = onDownloadChapter,
                         onChapterSelected = onChapterSelected,
                         onChapterSwipe = onChapterSwipe,
+                        onLocalChapter = onLocalChapter,
                     )
                 }
             }
@@ -457,6 +463,7 @@ fun MangaScreenLargeImpl(
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
     onTrackingClicked: (() -> Unit)?,
+    onLocalChapter: ((List<ChapterItem>, LocalChapterAction) -> Unit)?,
 
     // For tags menu
     onTagSearch: (String) -> Unit,
@@ -658,6 +665,7 @@ fun MangaScreenLargeImpl(
                                 onDownloadChapter = onDownloadChapter,
                                 onChapterSelected = onChapterSelected,
                                 onChapterSwipe = onChapterSwipe,
+                                onLocalChapter = onLocalChapter,
                             )
                         }
                     }
@@ -719,6 +727,7 @@ private fun LazyListScope.sharedChapterItems(
     onDownloadChapter: ((List<ChapterItem>, ChapterDownloadAction) -> Unit)?,
     onChapterSelected: (ChapterItem, Boolean, Boolean, Boolean) -> Unit,
     onChapterSwipe: (ChapterItem, LibraryPreferences.ChapterSwipeAction) -> Unit,
+    onLocalChapter: ((List<ChapterItem>, LocalChapterAction) -> Unit)?,
 ) {
     items(
         items = chapters,
@@ -729,6 +738,7 @@ private fun LazyListScope.sharedChapterItems(
         val context = LocalContext.current
 
         MangaChapterListItem(
+            localChapter = chapterItem.chapter.localChapter,
             title = if (manga.displayMode == Manga.CHAPTER_DISPLAY_NUMBER) {
                 stringResource(
                     R.string.display_mode_chapter,
@@ -778,6 +788,11 @@ private fun LazyListScope.sharedChapterItems(
             },
             onChapterSwipe = {
                 onChapterSwipe(chapterItem, it)
+            },
+            onLocalActionClick = if (onLocalChapter != null) {
+                { onLocalChapter(listOf(chapterItem), it) }
+            } else {
+                null
             },
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/LocalChapterComponents.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/LocalChapterComponents.kt
@@ -1,0 +1,60 @@
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.components.DropdownMenu
+import eu.kanade.tachiyomi.R
+import tachiyomi.presentation.core.components.material.IconButtonTokens
+
+@Composable
+fun LocalChapterIndicator(
+    modifier: Modifier = Modifier,
+    onClick: (LocalChapterAction) -> Unit,
+) {
+    var isMenuExpanded by remember { mutableStateOf(false) }
+    Box(
+        modifier = modifier
+            .size(IconButtonTokens.StateLayerSize)
+            .combinedClickable(
+                onLongClick = { isMenuExpanded = true },
+                onClick = { isMenuExpanded = true },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Folder,
+            contentDescription = null,
+            modifier = Modifier.size(26.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        DropdownMenu(expanded = isMenuExpanded, onDismissRequest = { isMenuExpanded = false }) {
+            DropdownMenuItem(
+                text = { Text(text = stringResource(R.string.action_delete)) },
+                onClick = {
+                    onClick(LocalChapterAction.DELETE)
+                    isMenuExpanded = false
+                },
+            )
+        }
+    }
+}
+
+enum class LocalChapterAction {
+    DELETE,
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -66,6 +66,7 @@ fun MangaChapterListItem(
     read: Boolean,
     bookmark: Boolean,
     selected: Boolean,
+    localChapter: Boolean,
     downloadIndicatorEnabled: Boolean,
     downloadStateProvider: () -> Download.State,
     downloadProgressProvider: () -> Int,
@@ -75,6 +76,7 @@ fun MangaChapterListItem(
     onClick: () -> Unit,
     onDownloadClick: ((ChapterDownloadAction) -> Unit)?,
     onChapterSwipe: (LibraryPreferences.ChapterSwipeAction) -> Unit,
+    onLocalActionClick: ((LocalChapterAction) -> Unit)?,
 ) {
     val haptic = LocalHapticFeedback.current
     val density = LocalDensity.current
@@ -204,13 +206,19 @@ fun MangaChapterListItem(
                     }
                 }
 
-                if (onDownloadClick != null) {
+                if (onDownloadClick != null && !localChapter) {
                     ChapterDownloadIndicator(
                         enabled = downloadIndicatorEnabled,
                         modifier = Modifier.padding(start = 4.dp),
                         downloadStateProvider = downloadStateProvider,
                         downloadProgressProvider = downloadProgressProvider,
                         onClick = onDownloadClick,
+                    )
+                }
+                if (onLocalActionClick != null && localChapter) {
+                    LocalChapterIndicator(
+                        modifier = Modifier.padding(start = 4.dp),
+                        onClick = onLocalActionClick,
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -23,6 +23,7 @@ import tachiyomi.presentation.core.components.WheelTextPicker
 fun DeleteChaptersDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
+    includeLocalChapter: Boolean,
 ) {
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -45,7 +46,15 @@ fun DeleteChaptersDialog(
             Text(text = stringResource(R.string.are_you_sure))
         },
         text = {
-            Text(text = stringResource(R.string.confirm_delete_chapters))
+            Text(
+                text = stringResource(
+                    if (includeLocalChapter) {
+                        R.string.confirm_delete_user_chapters
+                    } else {
+                        R.string.confirm_delete_chapters
+                    },
+                ),
+            )
         },
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupManager.kt
@@ -559,6 +559,7 @@ class BackupManager(
                     chapter.sourceOrder,
                     chapter.dateFetch,
                     chapter.dateUpload,
+                    chapter.localChapter,
                 )
             }
         }
@@ -583,6 +584,7 @@ class BackupManager(
                     dateFetch = null,
                     dateUpload = null,
                     chapterId = chapter.id,
+                    localChapter = null,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -21,6 +21,7 @@ data class BackupChapter(
     @ProtoNumber(9) var chapterNumber: Float = 0F,
     @ProtoNumber(10) var sourceOrder: Long = 0,
     @ProtoNumber(11) var lastModifiedAt: Long = 0,
+    @ProtoNumber(12) var localChapter: Boolean = false,
 ) {
     fun toChapterImpl(): Chapter {
         return Chapter.create().copy(
@@ -35,11 +36,12 @@ data class BackupChapter(
             dateUpload = this@BackupChapter.dateUpload,
             sourceOrder = this@BackupChapter.sourceOrder,
             lastModifiedAt = this@BackupChapter.lastModifiedAt,
+            localChapter = this@BackupChapter.localChapter,
         )
     }
 }
 
-val backupChapterMapper = { _: Long, _: Long, url: String, name: String, scanlator: String?, read: Boolean, bookmark: Boolean, lastPageRead: Long, chapterNumber: Double, source_order: Long, dateFetch: Long, dateUpload: Long, lastModifiedAt: Long ->
+val backupChapterMapper = { _: Long, _: Long, url: String, name: String, scanlator: String?, read: Boolean, bookmark: Boolean, lastPageRead: Long, chapterNumber: Double, source_order: Long, dateFetch: Long, dateUpload: Long, lastModifiedAt: Long, localChapter: Boolean ->
     BackupChapter(
         url = url,
         name = name,
@@ -52,5 +54,6 @@ val backupChapterMapper = { _: Long, _: Long, url: String, name: String, scanlat
         dateUpload = dateUpload,
         sourceOrder = source_order,
         lastModifiedAt = lastModifiedAt,
+        localChapter = localChapter,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -21,6 +21,8 @@ interface Chapter : SChapter, Serializable {
     var source_order: Int
 
     var last_modified: Long
+
+    var localChapter: Boolean
 }
 
 fun Chapter.toDomainChapter(): DomainChapter? {
@@ -39,5 +41,6 @@ fun Chapter.toDomainChapter(): DomainChapter? {
         chapterNumber = chapter_number.toDouble(),
         scanlator = scanlator,
         lastModifiedAt = last_modified,
+        localChapter = localChapter,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
@@ -28,6 +28,8 @@ class ChapterImpl : Chapter {
 
     override var last_modified: Long = 0
 
+    override var localChapter: Boolean = false
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || javaClass != other.javaClass) return false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.util.fastAny
 import androidx.core.net.toUri
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -107,6 +108,7 @@ class MangaScreen(
             onBackClicked = navigator::pop,
             onChapterClicked = { openChapter(context, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
+            onLocalChapter = screenModel::runLocalChapterActions.takeIf { successState.chapters.fastAny { it.chapter.localChapter } },
             onAddToLibraryClicked = {
                 screenModel.toggleFavorite()
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -155,6 +157,7 @@ class MangaScreen(
                         screenModel.toggleAllSelection(false)
                         screenModel.deleteChapters(dialog.chapters)
                     },
+                    includeLocalChapter = dialog.includeUserChapter,
                 )
             }
             is MangaScreenModel.Dialog.DuplicateManga -> DuplicateMangaDialog(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -468,7 +468,7 @@ class ReaderViewModel(
 
         // Determine which chapter should be deleted and enqueue
         val currentChapterPosition = chapterList.indexOf(currentChapter)
-        val chapterToDelete = chapterList.getOrNull(currentChapterPosition - removeAfterReadSlots)
+        val chapterToDelete = chapterList.filterNot { it.chapter.localChapter }.getOrNull(currentChapterPosition - removeAfterReadSlots)
 
         // If chapter is completely read, no need to download it
         chapterToDownload = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -5,6 +5,7 @@ import com.github.junrar.exception.UnsupportedRarV5Exception
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
@@ -57,6 +58,11 @@ class ChapterLoader(
 
                 chapter.state = ReaderChapter.State.Loaded(pages)
             } catch (e: Throwable) {
+                if (e is HttpException && chapter.chapter.localChapter) {
+                    val localChapterException = Exception(context.getString(R.string.local_chapter_not_found))
+                    chapter.state = ReaderChapter.State.Error(localChapterException)
+                    throw localChapterException
+                }
                 chapter.state = ReaderChapter.State.Error(e)
                 throw e
             }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterMapper.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterMapper.kt
@@ -2,8 +2,8 @@ package tachiyomi.data.chapter
 
 import tachiyomi.domain.chapter.model.Chapter
 
-val chapterMapper: (Long, Long, String, String, String?, Boolean, Boolean, Long, Double, Long, Long, Long, Long) -> Chapter =
-    { id, mangaId, url, name, scanlator, read, bookmark, lastPageRead, chapterNumber, sourceOrder, dateFetch, dateUpload, lastModifiedAt ->
+val chapterMapper: (Long, Long, String, String, String?, Boolean, Boolean, Long, Double, Long, Long, Long, Long, Boolean) -> Chapter =
+    { id, mangaId, url, name, scanlator, read, bookmark, lastPageRead, chapterNumber, sourceOrder, dateFetch, dateUpload, lastModifiedAt, localChapter ->
         Chapter(
             id = id,
             mangaId = mangaId,
@@ -18,5 +18,6 @@ val chapterMapper: (Long, Long, String, String, String?, Boolean, Boolean, Long,
             chapterNumber = chapterNumber,
             scanlator = scanlator,
             lastModifiedAt = lastModifiedAt,
+            localChapter = localChapter,
         )
     }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -28,6 +28,7 @@ class ChapterRepositoryImpl(
                         chapter.sourceOrder,
                         chapter.dateFetch,
                         chapter.dateUpload,
+                        chapter.localChapter,
                     )
                     val lastInsertId = chaptersQueries.selectLastInsertedRowId().executeAsOne()
                     chapter.copy(id = lastInsertId)
@@ -63,6 +64,7 @@ class ChapterRepositoryImpl(
                     dateFetch = chapterUpdate.dateFetch,
                     dateUpload = chapterUpdate.dateUpload,
                     chapterId = chapterUpdate.id,
+                    localChapter = chapterUpdate.localChapter,
                 )
             }
         }

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -14,6 +14,7 @@ CREATE TABLE chapters(
     date_fetch INTEGER NOT NULL,
     date_upload INTEGER NOT NULL,
     last_modified_at INTEGER NOT NULL DEFAULT 0,
+    local_chapter INTEGER AS Boolean NOT NULL DEFAULT 0,
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE
 );
@@ -62,8 +63,8 @@ DELETE FROM chapters
 WHERE _id IN :chapterIds;
 
 insert:
-INSERT INTO chapters(manga_id, url, name, scanlator, read, bookmark, last_page_read, chapter_number, source_order, date_fetch, date_upload, last_modified_at)
-VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, strftime('%s', 'now'));
+INSERT INTO chapters(manga_id, url, name, scanlator, read, bookmark, last_page_read, chapter_number, source_order, date_fetch, date_upload, last_modified_at, local_chapter)
+VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, strftime('%s', 'now'), :localChapter);
 
 update:
 UPDATE chapters
@@ -77,7 +78,8 @@ SET manga_id = coalesce(:mangaId, manga_id),
     chapter_number = coalesce(:chapterNumber, chapter_number),
     source_order = coalesce(:sourceOrder, source_order),
     date_fetch = coalesce(:dateFetch, date_fetch),
-    date_upload = coalesce(:dateUpload, date_upload)
+    date_upload = coalesce(:dateUpload, date_upload),
+    local_chapter = coalesce(:localChapter, local_chapter)
 WHERE _id = :chapterId;
 
 selectLastInsertedRowId:

--- a/data/src/main/sqldelight/tachiyomi/migrations/26.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/26.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE chapters ADD COLUMN local_chapter INTEGER AS Boolean NOT NULL DEFAULT 0;
+
+UPDATE chapters SET local_chapter = 0;

--- a/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
@@ -14,6 +14,7 @@ data class Chapter(
     val chapterNumber: Double,
     val scanlator: String?,
     val lastModifiedAt: Long,
+    val localChapter: Boolean,
 ) {
     val isRecognizedNumber: Boolean
         get() = chapterNumber >= 0f
@@ -33,6 +34,7 @@ data class Chapter(
             chapterNumber = -1.0,
             scanlator = null,
             lastModifiedAt = 0,
+            localChapter = false,
         )
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/chapter/model/ChapterUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/model/ChapterUpdate.kt
@@ -13,8 +13,9 @@ data class ChapterUpdate(
     val dateUpload: Long? = null,
     val chapterNumber: Double? = null,
     val scanlator: String? = null,
+    val localChapter: Boolean? = null,
 )
 
 fun Chapter.toChapterUpdate(): ChapterUpdate {
-    return ChapterUpdate(id, mangaId, read, bookmark, lastPageRead, dateFetch, sourceOrder, url, name, dateUpload, chapterNumber, scanlator)
+    return ChapterUpdate(id, mangaId, read, bookmark, lastPageRead, dateFetch, sourceOrder, url, name, dateUpload, chapterNumber, scanlator, localChapter)
 }

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -688,6 +688,7 @@
     <string name="error_saving_cover">Error saving cover</string>
     <string name="error_sharing_cover">Error sharing cover</string>
     <string name="confirm_delete_chapters">Are you sure you want to delete the selected chapters?</string>
+    <string name="confirm_delete_user_chapters">Are you sure you want to delete the selected chapters? They include local files that may be irretrievably lost after deletion.</string>
     <string name="chapter_settings">Chapter settings</string>
     <string name="confirm_set_chapter_settings">Are you sure you want to save these settings as default?</string>
     <string name="also_set_chapter_settings_for_library">Also apply to all entries in my library</string>
@@ -775,6 +776,7 @@
     <string name="transition_pages_loading">Loading pages…</string>
     <string name="transition_pages_error">Failed to load pages: %1$s</string>
     <string name="page_list_empty_error">No pages found</string>
+    <string name="local_chapter_not_found">Local chapter file not found</string>
     <string name="loader_not_implemented_error">Source not found</string>
     <string name="loader_rar5_error">RARv5 format is not supported</string>
     <plurals name="missing_chapters_warning">


### PR DESCRIPTION
Continuation of the work to eliminate orphans started in #9621. This is an implementation of my vision of Arkon's proposal.

The main idea is that when migrating a manga with download chapters and turning off the flag for deleting downloaded, they are moved to the new manga.
In this case, I want to move the chapter files to the new manga folder and create new entries in the database for them. The main features of these chapters are that they should be marked, ignored by any means of auto-deletion, not conflict with chapters from the new manga with the same names, and have the ability to be completely deleted by the user.
To do this, I added a new field to the chapter, localChapter, which is needed to mark chapters that are not related to the source, and came there during the migration or other user actions (there are still cases where this can be applied), they are marked with an Indicator on the right, replacing the usual download indicator, they are not deleting by manga sync and any auto-delete settings, and when deleted by the user, a modified alert appears, in case of deletion, complete deletion chapters, both file and entry from the database. If the user has deleted the chapter manually, then when trying to open it, he will receive a notification and it will be removed from the list when updating

| Migrated chapters| delete alert |
| ------- | ------- |
| ![migrated](https://github.com/tachiyomiorg/tachiyomi/assets/55978818/f83449df-6541-4f78-a296-f9bc8d45681f) | ![alert](https://github.com/tachiyomiorg/tachiyomi/assets/55978818/7d57c42d-aba1-4fbb-b8bd-dbc500881308) |

In general, this pr is needed to discuss the idea and show how I see it. If such a solution is acceptable, then it can also be used for other cases with orphans, for example, when synchronizing with the source, the downloaded chapter can be deleted from the database.


And a few more thoughts on the topic that I have been working on but am not yet sure of their appropriateness and would like to discuss:
1. How do you like the idea of making the ability to manage local chapters in the application? I was working on additional features for local chapters: editing and moving, I wanted to make it possible to edit chapter parameters and shuffle chapters between mangas, but I ended up putting it on pause. This functionality was made with an eye to the next item
2. I wanted to make it possible to manage chapters in local mangas directly in the application, I mean delete/move/change them and from here I have two questions: how about using the localChapter system for local manga chapters? What is the idea of a separate folder for the local source rather than making it a folder like all the other sources in the downloads folder, I understand that the current option seems more intuitive, but it would make it possible to use existing methods to manage chapters.
