### PR TITLE
[Download Queue] Move series to bottom

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueScreenModel.kt
@@ -84,13 +84,17 @@ class DownloadQueueScreenModel(
                         }
                         reorder(newDownloads)
                     }
-                    R.id.move_to_top_series -> {
+                    R.id.move_to_top_series, R.id.move_to_bottom_series -> {
                         val (selectedSeries, otherSeries) = adapter?.currentItems
                             ?.filterIsInstance<DownloadItem>()
                             ?.map(DownloadItem::download)
                             ?.partition { item.download.manga.id == it.manga.id }
                             ?: Pair(emptyList(), emptyList())
-                        reorder(selectedSeries + otherSeries)
+                        if (menuItem.itemId == R.id.move_to_top_series) {
+                            reorder(selectedSeries + otherSeries)
+                        } else {
+                            reorder(otherSeries + selectedSeries)
+                        }
                     }
                     R.id.cancel_download -> {
                         cancel(listOf(item.download))

--- a/app/src/main/res/menu/download_single.xml
+++ b/app/src/main/res/menu/download_single.xml
@@ -14,6 +14,10 @@
         android:title="@string/action_move_to_bottom" />
 
     <item
+        android:id="@+id/move_to_bottom_series"
+        android:title="@string/action_move_to_bottom_all_for_series" />
+
+    <item
         android:id="@+id/cancel_download"
         android:title="@string/action_cancel" />
 

--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="action_move_to_top">Move to top</string>
     <string name="action_move_to_top_all_for_series">Move series to top</string>
     <string name="action_move_to_bottom">Move to bottom</string>
+    <string name="action_move_to_bottom_all_for_series">Move series to bottom</string>
     <string name="action_install">Install</string>
     <string name="action_share">Share</string>
     <string name="action_save">Save</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Issue: https://github.com/tachiyomiorg/tachiyomi/issues/9816
This PR adds an option for user to move series to bottom in the download queue page. I've added text for English only since I'm assuming the translation for other languages will be done with Weblate because of the conversation in this PR: https://github.com/tachiyomiorg/tachiyomi/pull/6794

![image](https://github.com/tachiyomiorg/tachiyomi/assets/49599589/69e32ffb-37eb-483c-a52b-76a2971af593)