### PR TITLE
Allow extensions to open manga or chapter by URL

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -41,6 +41,7 @@ import tachiyomi.domain.category.interactor.UpdateCategory
 import tachiyomi.domain.category.repository.CategoryRepository
 import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.chapter.interactor.GetChapterByMangaId
+import tachiyomi.domain.chapter.interactor.GetChapterByUrlAndMangaId
 import tachiyomi.domain.chapter.interactor.SetMangaDefaultChapterFlags
 import tachiyomi.domain.chapter.interactor.ShouldUpdateDbChapter
 import tachiyomi.domain.chapter.interactor.UpdateChapter
@@ -56,6 +57,7 @@ import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFavorites
 import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
 import tachiyomi.domain.manga.interactor.GetMangaWithChapters
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
@@ -99,6 +101,7 @@ class DomainModule : InjektModule {
         addFactory { GetFavorites(get()) }
         addFactory { GetLibraryManga(get()) }
         addFactory { GetMangaWithChapters(get(), get()) }
+        addFactory { GetMangaByUrlAndSourceId(get()) }
         addFactory { GetManga(get()) }
         addFactory { GetNextChapters(get(), get(), get()) }
         addFactory { ResetViewerFlags(get()) }
@@ -126,6 +129,7 @@ class DomainModule : InjektModule {
         addSingletonFactory<ChapterRepository> { ChapterRepositoryImpl(get()) }
         addFactory { GetChapter(get()) }
         addFactory { GetChapterByMangaId(get()) }
+        addFactory { GetChapterByUrlAndMangaId(get()) }
         addFactory { UpdateChapter(get()) }
         addFactory { SetReadStatus(get(), get(), get(), get()) }
         addFactory { ShouldUpdateDbChapter() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.content.ContextCompat.startActivity
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -51,14 +50,14 @@ class DeepLinkScreen(
                 }
                 is DeepLinkScreenModel.State.Result -> {
                     val resultState = state as DeepLinkScreenModel.State.Result
-                    if(resultState.chapterId == null){
+                    if (resultState.chapterId == null) {
                         navigator.replace(
                             MangaScreen(
                                 resultState.manga.id,
                                 true,
                             ),
                         )
-                    }else{
+                    } else {
                         navigator.pop()
                         ReaderActivity.newIntent(
                             context,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat.startActivity
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -14,6 +16,7 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -23,6 +26,7 @@ class DeepLinkScreen(
 
     @Composable
     override fun Content() {
+        val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
 
         val screenModel = rememberScreenModel {
@@ -46,12 +50,22 @@ class DeepLinkScreen(
                     navigator.replace(GlobalSearchScreen(query))
                 }
                 is DeepLinkScreenModel.State.Result -> {
-                    navigator.replace(
-                        MangaScreen(
-                            (state as DeepLinkScreenModel.State.Result).manga.id,
-                            true,
-                        ),
-                    )
+                    val resultState = state as DeepLinkScreenModel.State.Result
+                    if(resultState.chapterId == null){
+                        navigator.replace(
+                            MangaScreen(
+                                resultState.manga.id,
+                                true,
+                            ),
+                        )
+                    }else{
+                        navigator.pop()
+                        ReaderActivity.newIntent(
+                            context,
+                            resultState.manga.id,
+                            resultState.chapterId,
+                        ).also(context::startActivity)
+                    }
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
@@ -11,10 +11,10 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ResolvableSource
+import eu.kanade.tachiyomi.source.online.UriType
 import kotlinx.coroutines.flow.update
-import logcat.LogPriority
-import logcat.logcat
 import tachiyomi.core.util.lang.launchIO
+import tachiyomi.core.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapterByUrlAndMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
@@ -31,29 +31,33 @@ class DeepLinkScreenModel(
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getChapterByUrlAndMangaId: GetChapterByUrlAndMangaId = Injekt.get(),
     private val getMangaByUrlAndSourceId: GetMangaByUrlAndSourceId = Injekt.get(),
-    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
+    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get(),
 ) : StateScreenModel<DeepLinkScreenModel.State>(State.Loading) {
-
 
     init {
         coroutineScope.launchIO {
             val source = sourceManager.getCatalogueSources()
                 .filterIsInstance<ResolvableSource>()
-                .filter{ it.id.toString() !in sourcePreferences.disabledSources().get() }
-                .firstOrNull { it.canResolveUri(query) }
+                .filter { it.id.toString() !in sourcePreferences.disabledSources().get() }
+                .firstOrNull { it.getUriType(query) != UriType.Unknown }
 
-            val manga = source?.getManga(query)?.let { getMangaFromSManga(it, source.id) }
+            val manga = source?.getManga(query)?.let {
+                getMangaFromSManga(it, source.id)
+            }
 
-            val chapter = if(source?.isChapterUri(query) == true && manga != null){
+            val chapter = if (source?.getUriType(query) == UriType.Chapter && manga != null) {
                 source.getChapter(query)?.let { getChapterFromSChapter(it, manga, source) }
-            }else null
+            } else {
+                null
+            }
 
             mutableState.update {
                 if (manga == null) {
                     State.NoResults
                 } else {
-                    if(chapter == null) State.Result(manga)
-                    else {
+                    if (chapter == null) {
+                        State.Result(manga)
+                    } else {
                         State.Result(manga, chapter.id)
                     }
                 }
@@ -62,17 +66,15 @@ class DeepLinkScreenModel(
     }
 
     private suspend fun getChapterFromSChapter(sChapter: SChapter, manga: Manga, source: Source): Chapter? {
-        val localChapter = try{
-            getChapterByUrlAndMangaId.await(sChapter.url, manga.id)
-        }catch (e: Exception){
-            logcat(LogPriority.ERROR) { e.message ?: "Error getting chapter from url" }
-            null
-        }
-        return if(localChapter == null){
+        val localChapter = getChapterByUrlAndMangaId.await(sChapter.url, manga.id)
+
+        return if (localChapter == null) {
             val sourceChapters = source.getChapterList(manga.toSManga())
             val newChapters = syncChaptersWithSource.await(sourceChapters, manga, source, false)
             newChapters.find { it.url == sChapter.url }
-        }else localChapter
+        } else {
+            localChapter
+        }
     }
 
     private suspend fun getMangaFromSManga(sManga: SManga, sourceId: Long): Manga {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
@@ -3,10 +3,22 @@ package eu.kanade.tachiyomi.ui.deeplink
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.coroutineScope
+import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.model.toDomainManga
+import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ResolvableSource
 import kotlinx.coroutines.flow.update
+import logcat.LogPriority
+import logcat.logcat
 import tachiyomi.core.util.lang.launchIO
+import tachiyomi.domain.chapter.interactor.GetChapterByUrlAndMangaId
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
@@ -15,23 +27,63 @@ import uy.kohesive.injekt.api.get
 class DeepLinkScreenModel(
     query: String = "",
     private val sourceManager: SourceManager = Injekt.get(),
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val getChapterByUrlAndMangaId: GetChapterByUrlAndMangaId = Injekt.get(),
+    private val getMangaByUrlAndSourceId: GetMangaByUrlAndSourceId = Injekt.get(),
+    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
 ) : StateScreenModel<DeepLinkScreenModel.State>(State.Loading) {
+
 
     init {
         coroutineScope.launchIO {
-            val manga = sourceManager.getCatalogueSources()
+            val source = sourceManager.getCatalogueSources()
                 .filterIsInstance<ResolvableSource>()
-                .filter { it.canResolveUri(query) }
-                .firstNotNullOfOrNull { it.getManga(query)?.toDomainManga(it.id) }
+                .filter{ it.id.toString() !in sourcePreferences.disabledSources().get() }
+                .firstOrNull { it.canResolveUri(query) }
+
+            val manga = source?.getManga(query)?.let { getMangaFromSManga(it, source.id) }
+
+            logcat{ "isChapterUri ${source?.isChapterUri(query)}" }
+
+            val chapter = if(source?.isChapterUri(query) == true && manga != null){
+                source.getChapter(query)?.let { getChapterFromSChapter(it, manga, source) }
+            }else null
+
+            logcat{ "chapter $chapter" }
 
             mutableState.update {
                 if (manga == null) {
                     State.NoResults
                 } else {
-                    State.Result(manga)
+                    val localManga = networkToLocalManga.await(manga)
+                    if(chapter == null) State.Result(localManga)
+                    else {
+                        State.Result(manga, chapter.id)
+                    }
                 }
             }
         }
+    }
+
+    private suspend fun getChapterFromSChapter(sChapter: SChapter, manga: Manga, source: Source): Chapter? {
+        val localChapter = try{
+            getChapterByUrlAndMangaId.await(sChapter.url, manga.id)!!
+        }catch (e: Exception){
+
+            logcat(LogPriority.ERROR) { e.message ?: "Error getting chapter from url" }
+            null
+        }
+        return if(localChapter == null){
+            val sourceChapters = source.getChapterList(manga.toSManga())
+            val newChapters = syncChaptersWithSource.await(sourceChapters, manga, source, false)
+            newChapters.find { it.url == sChapter.url }
+        }else localChapter
+    }
+
+    private suspend fun getMangaFromSManga(sManga: SManga, sourceId: Long): Manga {
+        return getMangaByUrlAndSourceId.awaitManga(sManga.url, sourceId)
+            ?: networkToLocalManga.await(sManga.toDomainManga(sourceId))
     }
 
     sealed interface State {
@@ -42,6 +94,6 @@ class DeepLinkScreenModel(
         data object NoResults : State
 
         @Immutable
-        data class Result(val manga: Manga) : State
+        data class Result(val manga: Manga, val chapterId: Long? = null) : State
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
@@ -6,7 +6,6 @@ import cafe.adriel.voyager.core.model.coroutineScope
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.model.toDomainManga
 import eu.kanade.domain.manga.model.toSManga
-import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
@@ -14,7 +13,6 @@ import eu.kanade.tachiyomi.source.online.ResolvableSource
 import eu.kanade.tachiyomi.source.online.UriType
 import kotlinx.coroutines.flow.update
 import tachiyomi.core.util.lang.launchIO
-import tachiyomi.core.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapterByUrlAndMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
@@ -27,7 +25,6 @@ import uy.kohesive.injekt.api.get
 class DeepLinkScreenModel(
     query: String = "",
     private val sourceManager: SourceManager = Injekt.get(),
-    private val sourcePreferences: SourcePreferences = Injekt.get(),
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getChapterByUrlAndMangaId: GetChapterByUrlAndMangaId = Injekt.get(),
     private val getMangaByUrlAndSourceId: GetMangaByUrlAndSourceId = Injekt.get(),
@@ -38,7 +35,6 @@ class DeepLinkScreenModel(
         coroutineScope.launchIO {
             val source = sourceManager.getCatalogueSources()
                 .filterIsInstance<ResolvableSource>()
-                .filter { it.id.toString() !in sourcePreferences.disabledSources().get() }
                 .firstOrNull { it.getUriType(query) != UriType.Unknown }
 
             val manga = source?.getManga(query)?.let {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenModel.kt
@@ -44,20 +44,15 @@ class DeepLinkScreenModel(
 
             val manga = source?.getManga(query)?.let { getMangaFromSManga(it, source.id) }
 
-            logcat{ "isChapterUri ${source?.isChapterUri(query)}" }
-
             val chapter = if(source?.isChapterUri(query) == true && manga != null){
                 source.getChapter(query)?.let { getChapterFromSChapter(it, manga, source) }
             }else null
-
-            logcat{ "chapter $chapter" }
 
             mutableState.update {
                 if (manga == null) {
                     State.NoResults
                 } else {
-                    val localManga = networkToLocalManga.await(manga)
-                    if(chapter == null) State.Result(localManga)
+                    if(chapter == null) State.Result(manga)
                     else {
                         State.Result(manga, chapter.id)
                     }
@@ -68,9 +63,8 @@ class DeepLinkScreenModel(
 
     private suspend fun getChapterFromSChapter(sChapter: SChapter, manga: Manga, source: Source): Chapter? {
         val localChapter = try{
-            getChapterByUrlAndMangaId.await(sChapter.url, manga.id)!!
+            getChapterByUrlAndMangaId.await(sChapter.url, manga.id)
         }catch (e: Exception){
-
             logcat(LogPriority.ERROR) { e.message ?: "Error getting chapter from url" }
             null
         }

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
@@ -1,7 +1,5 @@
 package tachiyomi.domain.chapter.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.repository.ChapterRepository
 
@@ -13,7 +11,6 @@ class GetChapterByUrlAndMangaId(
         return try {
             chapterRepository.getChapterByUrlAndMangaId(url, sourceId)
         } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
             null
         }
     }

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
@@ -1,0 +1,20 @@
+package tachiyomi.domain.chapter.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.util.system.logcat
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.chapter.repository.ChapterRepository
+
+class GetChapterByUrlAndMangaId(
+    private val chapterRepository: ChapterRepository,
+) {
+
+    suspend fun await(url: String, sourceId: Long): Chapter? {
+        return try {
+            chapterRepository.getChapterByUrlAndMangaId(url, sourceId)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            null
+        }
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaByUrlAndSourceId.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaByUrlAndSourceId.kt
@@ -4,7 +4,7 @@ import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 
 class GetMangaByUrlAndSourceId(
-    private val mangaRepository: MangaRepository
+    private val mangaRepository: MangaRepository,
 ) {
     suspend fun awaitManga(url: String, sourceId: Long): Manga? {
         return mangaRepository.getMangaByUrlAndSourceId(url, sourceId)

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaByUrlAndSourceId.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaByUrlAndSourceId.kt
@@ -1,0 +1,12 @@
+package tachiyomi.domain.manga.interactor
+
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.repository.MangaRepository
+
+class GetMangaByUrlAndSourceId(
+    private val mangaRepository: MangaRepository
+) {
+    suspend fun awaitManga(url: String, sourceId: Long): Manga? {
+        return mangaRepository.getMangaByUrlAndSourceId(url, sourceId)
+    }
+}

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -290,6 +290,13 @@ abstract class HttpSource : CatalogueSource {
     protected abstract fun chapterListParse(response: Response): List<SChapter>
 
     /**
+     * Parses the response from the site and returns a SChapter Object.
+     *
+     * @param response the response from the site.
+     */
+    protected abstract fun chapterPageParse(response: Response): SChapter
+
+    /**
      * Get the list of pages a chapter has. Pages should be returned
      * in the expected order; the index is ignored.
      *

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ResolvableSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ResolvableSource.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.source.online
 
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 
 /**
@@ -18,9 +19,30 @@ interface ResolvableSource : Source {
     fun canResolveUri(uri: String): Boolean
 
     /**
+     * Called if canHandleUri is true. Checks if it's a chapter Uri.
+     *
+     * @since extensions-lib 1.5
+     */
+    fun isChapterUri(uri: String): Boolean
+
+    /**
+     * Called if canHandleUri is true. Checks if it's a manga Uri.
+     *
+     * @since extensions-lib 1.5
+     */
+    fun isMangaUri(uri: String): Boolean
+
+    /**
      * Called if canHandleUri is true. Returns the corresponding SManga, if possible.
      *
      * @since extensions-lib 1.5
      */
     suspend fun getManga(uri: String): SManga?
+
+    /**
+     * Called if canHandleUri is true. Returns the corresponding SChapter, if possible.
+     *
+     * @since extensions-lib 1.5
+     */
+    suspend fun getChapter(uri: String): SChapter?
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ResolvableSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ResolvableSource.kt
@@ -12,25 +12,12 @@ import eu.kanade.tachiyomi.source.model.SManga
 interface ResolvableSource : Source {
 
     /**
-     * Whether this source may potentially handle the given URI.
+     * Returns the UriType of the uri input.
+     * Returns Unknown if unable to resolve the URI
      *
      * @since extensions-lib 1.5
      */
-    fun canResolveUri(uri: String): Boolean
-
-    /**
-     * Called if canHandleUri is true. Checks if it's a chapter Uri.
-     *
-     * @since extensions-lib 1.5
-     */
-    fun isChapterUri(uri: String): Boolean
-
-    /**
-     * Called if canHandleUri is true. Checks if it's a manga Uri.
-     *
-     * @since extensions-lib 1.5
-     */
-    fun isMangaUri(uri: String): Boolean
+    fun getUriType(uri: String): UriType
 
     /**
      * Called if canHandleUri is true. Returns the corresponding SManga, if possible.
@@ -45,4 +32,10 @@ interface ResolvableSource : Source {
      * @since extensions-lib 1.5
      */
     suspend fun getChapter(uri: String): SChapter?
+}
+
+sealed interface UriType {
+    object Manga : UriType
+    object Chapter : UriType
+    object Unknown : UriType
 }


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Added functions to ResolvableSource to cater for getting chapters via links 
Automatically load MangaScreen and ReaderActivity from links

Attached is the issue link
https://github.com/tachiyomiorg/tachiyomi/issues/9188

https://github.com/tachiyomiorg/tachiyomi/assets/63104739/54f071a6-a3ba-47c1-afbe-44e2b8577391


![ezgif com-resize](https://github.com/tachiyomiorg/tachiyomi/assets/63104739/532c763f-681d-4b79-ba3d-ab436d4a9205)
