### PR TITLE
Continue Reading Button size/style normalization

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -127,13 +127,14 @@ private fun BoxScope.CoverTextOverlay(
             .align(Alignment.BottomCenter),
     )
     Row(
-        modifier = Modifier.align(Alignment.BottomStart),
+        modifier = Modifier.align(Alignment.BottomStart)
+            .height(ContinueReadingButtonSize * 2),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         GridItemTitle(
             modifier = Modifier
                 .weight(1f)
-                .padding(ContinueReadingButtonGridPadding),
+                .padding(start = ContinueReadingButtonGridPadding, end = ContinueReadingButtonGridPadding),
             title = title,
             style = MaterialTheme.typography.titleSmall.copy(
                 color = Color.White,

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -48,7 +48,7 @@ object CommonMangaItemDefaults {
     const val BrowseFavoriteCoverAlpha = 0.34f
 }
 
-private val ContinueReadingButtonSize = 26.dp
+private val ContinueReadingButtonSize = 24.dp
 private val ContinueReadingButtonGridPadding = 8.dp
 private val ContinueReadingButtonListSpacing = 10.dp
 
@@ -128,12 +128,12 @@ private fun BoxScope.CoverTextOverlay(
     )
     Row(
         modifier = Modifier.align(Alignment.BottomStart),
-        verticalAlignment = Alignment.Bottom,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         GridItemTitle(
             modifier = Modifier
                 .weight(1f)
-                .padding(8.dp),
+                .padding(ContinueReadingButtonGridPadding),
             title = title,
             style = MaterialTheme.typography.titleSmall.copy(
                 color = Color.White,
@@ -148,7 +148,6 @@ private fun BoxScope.CoverTextOverlay(
             ContinueReadingButton(
                 modifier = Modifier.padding(
                     end = ContinueReadingButtonGridPadding,
-                    bottom = ContinueReadingButtonGridPadding,
                 ),
                 onClickContinueReading = onClickContinueReading,
             )
@@ -368,7 +367,7 @@ private fun ContinueReadingButton(
         FilledIconButton(
             onClick = onClickContinueReading,
             modifier = Modifier.size(ContinueReadingButtonSize),
-            shape = MaterialTheme.shapes.large,
+            shape = MaterialTheme.shapes.small,
             colors = IconButtonDefaults.filledIconButtonColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
                 contentColor = contentColorFor(MaterialTheme.colorScheme.primaryContainer),

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -48,9 +48,9 @@ object CommonMangaItemDefaults {
     const val BrowseFavoriteCoverAlpha = 0.34f
 }
 
-private val ContinueReadingButtonSize = 32.dp
-private val ContinueReadingButtonGridPadding = 6.dp
-private val ContinueReadingButtonListSpacing = 8.dp
+private val ContinueReadingButtonSize = 26.dp
+private val ContinueReadingButtonGridPadding = 8.dp
+private val ContinueReadingButtonListSpacing = 10.dp
 
 private const val GridSelectedCoverAlpha = 0.76f
 
@@ -368,7 +368,7 @@ private fun ContinueReadingButton(
         FilledIconButton(
             onClick = onClickContinueReading,
             modifier = Modifier.size(ContinueReadingButtonSize),
-            shape = MaterialTheme.shapes.small,
+            shape = MaterialTheme.shapes.large,
             colors = IconButtonDefaults.filledIconButtonColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
                 contentColor = contentColorFor(MaterialTheme.colorScheme.primaryContainer),
@@ -377,7 +377,7 @@ private fun ContinueReadingButton(
             Icon(
                 imageVector = Icons.Filled.PlayArrow,
                 contentDescription = "",
-                modifier = Modifier.size(16.dp),
+                modifier = Modifier.size(18.dp),
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -128,7 +128,8 @@ private fun BoxScope.CoverTextOverlay(
     )
     Row(
         modifier = Modifier.align(Alignment.BottomStart)
-            .height(ContinueReadingButtonSize * 2),
+            .height(ContinueReadingButtonSize + ContinueReadingButtonGridPadding * 3)
+            .padding(bottom = ContinueReadingButtonGridPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         GridItemTitle(


### PR DESCRIPTION
Goal of the pull is to make style the ContinueReadingButton less knockout-annoying (balanced with the surrounding elements)

<img src="https://github.com/tachiyomiorg/tachiyomi/assets/35057681/52ffe089-a0ac-454b-b59d-4aacd32a620b" width="400" />
<img src="https://github.com/tachiyomiorg/tachiyomi/assets/35057681/027e01e9-bd10-4ada-8705-190c0832c5b8" width="400" />
<img src="https://github.com/tachiyomiorg/tachiyomi/assets/35057681/65239fd4-b2ba-476b-81e8-aed84c0e4fa5" width="400" />
<img src="https://github.com/tachiyomiorg/tachiyomi/assets/35057681/e67a2006-dc3f-4284-98b6-a57776f79350" width="400" />

