### PR TITLE
Fix reading problem with downloaded chaps

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -140,7 +140,7 @@ class ReaderViewModel @JvmOverloads constructor(
     /**
      * The list of chapters. It gets initialized lazily through the getter.
      */
-    private val chapterList : List<ReaderChapter>
+    private val chapterList: List<ReaderChapter>
         get() {
             if (_chapterList == null) {
                 _chapterList = initChapterList()
@@ -155,12 +155,11 @@ class ReaderViewModel @JvmOverloads constructor(
 
     private var chapterToDownload: Download? = null
 
-
     /**
      * Function to retrieve Chapter list for the active manga. It gets retrieved lazily through the chapterList val and
      * should be accessed for the first time in a background thread to avoid blocking the UI.
      */
-    private fun initChapterList() : List<ReaderChapter> {
+    private fun initChapterList(): List<ReaderChapter> {
         val manga = manga!!
         val chapters = runBlocking { getChaptersByMangaId.await(manga.id, applyScanlatorFilter = true) }
 
@@ -443,7 +442,7 @@ class ReaderViewModel @JvmOverloads constructor(
         val manga = manga!!
         _chapterList = chapterList.filter { chapter ->
             downloadManager.isChapterDownloaded(
-                chapter.chapter.name, chapter.chapter.scanlator, manga.title, manga.source
+                chapter.chapter.name, chapter.chapter.scanlator, manga.title, manga.source,
             )
         }
         val newIndex = chapterList.indexOf(currChapters.currChapter)


### PR DESCRIPTION
Fixes #10016. I chose to detect if an UnknownHostException is thrown. If the device is additionally offline, the non-downloaded chapters are filtered out from the chapterlist (had to make the chapterList mutable for that to work, I'm not sure if that's fine).
This is my first time working on an open source project, so I'm still quite new to this :)
  
 Here is the before and after (ch. 1, 3, 5 and 10 are downloaded. I'm trying to scroll between them and trying to move to an adjacent chapter):

### Images & Videos
| Before | After |
| ------- | ------- |
| [Video Before](https://github.com/tachiyomiorg/tachiyomi/assets/87513231/60d5e60b-5a5e-42eb-a5aa-1ce0f0000cfe) |  [Video After](https://github.com/tachiyomiorg/tachiyomi/assets/87513231/03857c6b-3f31-449f-a499-2a06a7cbe351) |
| ![](https://github.com/tachiyomiorg/tachiyomi/assets/87513231/183d80e0-49a2-410e-aab7-59b6e0905544) | ![](https://github.com/tachiyomiorg/tachiyomi/assets/87513231/1b9a9181-a614-42e6-8aaf-669466c49892) |

