### PR TITLE
fix Can't scroll down to the bottom of the webtoon on the last chapter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -214,6 +214,9 @@ class WebtoonRecyclerView @JvmOverloads constructor(
             if (!isZooming && doubleTapZoom) {
                 if (scaleX != DEFAULT_RATE) {
                     zoom(currentScale, DEFAULT_RATE, x, 0f, y, 0f)
+                    layoutParams.height = originalHeight
+                    halfHeight = layoutParams.height / 2
+                    requestLayout()
                 } else {
                     val toScale = 2f
                     val toX = (halfWidth - ev.x) * (toScale - 1)


### PR DESCRIPTION
fix #3052
I think the problem come from scaling, where the layout height is updated. However, when double-clicking, the layout height wasn't reset to original height.