### PR TITLE
Add ability for user to configure chapter cache size

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -51,6 +51,7 @@ sealed class Preference {
             val value: Int,
             val min: Int = 0,
             val max: Int,
+            val steps: Int = 0,
             override val title: String = "",
             override val subtitle: String? = null,
             override val icon: ImageVector? = null,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -83,6 +83,7 @@ internal fun PreferenceItem(
                     label = item.title,
                     min = item.min,
                     max = item.max,
+                    steps = item.steps,
                     value = item.value,
                     valueText = item.subtitle.takeUnless { it.isNullOrEmpty() } ?: item.value.toString(),
                     onChange = {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -252,9 +252,12 @@ object SettingsDataScreen : SearchableSettings {
         val scope = rememberCoroutineScope()
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
 
+        val chapterCacheSizePref = libraryPreferences.chapterCacheSize()
+
         val chapterCache = remember { Injekt.get<ChapterCache>() }
         var cacheReadableSizeSema by remember { mutableIntStateOf(0) }
         val cacheReadableSize = remember(cacheReadableSizeSema) { chapterCache.readableSize }
+        val chapterCacheSize by chapterCacheSizePref.collectAsState()
 
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_storage_usage),
@@ -287,6 +290,18 @@ object SettingsDataScreen : SearchableSettings {
                                 withUIContext { context.toast(MR.strings.cache_delete_error) }
                             }
                         }
+                    },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = chapterCacheSize,
+                    title = stringResource(MR.strings.pref_chapter_cache_size),
+                    subtitle = stringResource(MR.strings.chapter_cache_size, chapterCacheSize),
+                    min = LibraryPreferences.CHAPTER_CACHE_SIZE_MIN,
+                    max = LibraryPreferences.CHAPTER_CACHE_SIZE_MAX,
+                    steps = 7,
+                    onValueChanged = {
+                        chapterCacheSizePref.set(it)
+                        true
                     },
                 ),
                 Preference.PreferenceItem.SwitchPreference(

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -190,6 +190,8 @@ class LibraryPreferences(
         )
     }
 
+    fun chapterCacheSize() = preferenceStore.getInt("chapter_cache_size", 100)
+
     fun autoClearChapterCache() = preferenceStore.getBoolean("auto_clear_chapter_cache", false)
 
     // endregion
@@ -224,5 +226,8 @@ class LibraryPreferences(
         const val MANGA_HAS_UNREAD = "manga_fully_read"
         const val MANGA_NON_READ = "manga_started"
         const val MANGA_OUTSIDE_RELEASE_PERIOD = "manga_outside_release_period"
+
+        const val CHAPTER_CACHE_SIZE_MIN = 100
+        const val CHAPTER_CACHE_SIZE_MAX = 500
     }
 }

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -539,6 +539,8 @@
     <string name="used_cache">Used: %1$s</string>
     <string name="cache_deleted">Cache cleared, %1$d files deleted</string>
     <string name="cache_delete_error">Error occurred while clearing</string>
+    <string name="pref_chapter_cache_size">Chapter cache size</string>
+    <string name="chapter_cache_size">%1$s MB</string>
     <string name="pref_auto_clear_chapter_cache">Clear chapter cache on app launch</string>
 
     <!-- Sync section -->

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -161,6 +161,7 @@ fun SliderItem(
     onChange: (Int) -> Unit,
     max: Int,
     min: Int = 0,
+    steps: Int = 0,
 ) {
     val haptic = LocalHapticFeedback.current
 
@@ -193,7 +194,7 @@ fun SliderItem(
             },
             modifier = Modifier.weight(1.5f),
             valueRange = min.toFloat()..max.toFloat(),
-            steps = max - min,
+            steps = if (steps > 0) steps else max - min,
         )
     }
 }


### PR DESCRIPTION
Implemented [#10262](https://github.com/tachiyomiorg/tachiyomi/issues/10262).

As per the feature request, this adds an option to settings under 'Data and storage' called 'Chapter cache size' which allows the user to configure the maximum chapter cache size for themselves. I've chosen to implement a slider of which the acceptable range of values is 100MB - 500MB, in steps of 50MB.

This required making some slight alterations so that the maximum cache size is set to the slider value every time 'Clear chapter cache' is clicked (rather than just setting it once on startup and never again), as well as some minor changes to the Slider object to allow for the 50MB steps I wanted (the Slider object already had a steps feature implemented but was just not able to be passed a steps parameter until now).