### PR TITLE
Use transaction on restore to go brr.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -57,22 +57,24 @@ class MangaRestorer(
         backupManga: BackupManga,
         backupCategories: List<BackupCategory>,
     ) {
-        val dbManga = findExistingManga(backupManga)
-        val manga = backupManga.getMangaImpl()
-        val restoredManga = if (dbManga == null) {
-            restoreNewManga(manga)
-        } else {
-            restoreExistingManga(manga, dbManga)
-        }
+        handler.await(inTransaction = true) {
+            val dbManga = findExistingManga(backupManga)
+            val manga = backupManga.getMangaImpl()
+            val restoredManga = if (dbManga == null) {
+                restoreNewManga(manga)
+            } else {
+                restoreExistingManga(manga, dbManga)
+            }
 
-        restoreMangaDetails(
-            manga = restoredManga,
-            chapters = backupManga.chapters,
-            categories = backupManga.categories,
-            backupCategories = backupCategories,
-            history = backupManga.history + backupManga.brokenHistory.map { it.toBackupHistory() },
-            tracks = backupManga.tracking,
-        )
+            restoreMangaDetails(
+                manga = restoredManga,
+                chapters = backupManga.chapters,
+                categories = backupManga.categories,
+                backupCategories = backupCategories,
+                history = backupManga.history + backupManga.brokenHistory.map { it.toBackupHistory() },
+                tracks = backupManga.tracking,
+            )
+        }
     }
 
     private suspend fun findExistingManga(backupManga: BackupManga): Manga? {


### PR DESCRIPTION
By wrapping the restoration steps within a single database transaction, we've achieved a considerable reduction in the overall time required to restore large dataset of manga entries into both fresh and non-fresh databases.

# Changes
- Wrapped the entire `restoreManga` function within a transaction block using `handler.await(inTransaction = true)`.

# Performance Gains
- Fresh DB restores have shown a 57.31% speed increase, reducing the time from 14 minutes to approximately 6 minutes.

- Non-fresh DB restores have shown an even more impressive 62.57% speed increase, slashing the time from 27 minutes to around 10 minutes.

# Scope of Optimization
- The optimization was tested on a dataset containing approximately 3,053 manga entries, each with a varying number of chapters.

edit: added images.

### With transaction (fresh db)
![image](https://github.com/tachiyomiorg/tachiyomi/assets/41852205/5bd32b04-8461-4702-b8bb-2c428aa70cf2)

### Without transaction (fresh db)
![image](https://github.com/tachiyomiorg/tachiyomi/assets/41852205/9dd29608-c437-49ed-bd47-6b1fb401b791)

### With transaction (not fresh db)
![image](https://github.com/tachiyomiorg/tachiyomi/assets/41852205/67955664-ab9d-48c7-99f1-4be223d69af7)

### Without transaction (not fresh db)
![image](https://github.com/tachiyomiorg/tachiyomi/assets/41852205/e2824d97-230f-4750-b5f1-037018b5892c)
